### PR TITLE
[debian] adds missing dependency libtinyxml22-dev

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: kodi-pvr-dvblink
 Priority: extra
 Maintainer: Nobody <nobody@kodi.tv>
-Build-Depends: debhelper (>= 9.0.0), cmake, kodi-pvr-dev,
+Build-Depends: debhelper (>= 9.0.0), cmake, libtinyxml2-dev, kodi-pvr-dev,
                libkodiplatform-dev, kodi-addon-dev
 Standards-Version: 3.9.4
 Section: libs


### PR DESCRIPTION
@wsnipex ping
