### PR TITLE
Minimal support for PVR Addon API 1.9.7

### DIFF
--- a/pvr.dvblink/addon.xml
+++ b/pvr.dvblink/addon.xml
@@ -6,7 +6,7 @@
   provider-name="DVBLogic">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="1.9.6"/>
+    <import addon="xbmc.pvr" version="1.9.7"/>
   </requires>
   <extension
     point="xbmc.pvrclient"

--- a/pvr.dvblink/addon.xml
+++ b/pvr.dvblink/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.dvblink"
-  version="1.10.6"
+  version="1.11.0"
   name="DVBLink PVR Client"
   provider-name="DVBLogic">
   <requires>

--- a/pvr.dvblink/changelog.txt
+++ b/pvr.dvblink/changelog.txt
@@ -1,3 +1,6 @@
+[B]Version 1.11.0[/B]
+Updated to PVR API v1.9.7
+
 [B]Version 1.10.6[/B]
 Updated: language files from Transifex
 

--- a/src/DVBLinkClient.cpp
+++ b/src/DVBLinkClient.cpp
@@ -347,6 +347,10 @@ PVR_ERROR DVBLinkClient::GetTimers(ADDON_HANDLE handle)
 
     PVR_TIMER xbmcTimer;
     memset(&xbmcTimer, 0, sizeof(PVR_TIMER));
+
+    /* TODO: Implement own timer types to get support for the timer features introduced with PVR API 1.9.7 */
+    xbmcTimer.iTimerType = PVR_TIMER_TYPE_NONE;
+
     //fake index
     xbmcTimer.iClientIndex = i;
     //misuse strDirectory to keep id of the timer
@@ -361,8 +365,6 @@ PVR_ERROR DVBLinkClient::GetTimers(ADDON_HANDLE handle)
       xbmcTimer.state = PVR_TIMER_STATE_CONFLICT_NOK;
     if (!rec->GetProgram().IsRecord)
       xbmcTimer.state = PVR_TIMER_STATE_CANCELLED;
-
-    xbmcTimer.bIsRepeating = rec->GetProgram().IsRepeatRecord;
 
     xbmcTimer.iEpgUid = rec->GetProgram().GetStartTime();
     
@@ -470,7 +472,7 @@ PVR_ERROR DVBLinkClient::AddTimer(const PVR_TIMER &timer)
         time_t start_time = timer.startTime;
         time_t duration = timer.endTime - timer.startTime;
         long day_mask = 0;
-        if (timer.bIsRepeating)
+        if (timer.iWeekdays > 0) // repeating timer?
         {
             //change day mask to DVBLink server format (Sun - first day)
             bool bcarry = (timer.iWeekdays & 0x40) == 0x40;
@@ -519,7 +521,7 @@ PVR_ERROR DVBLinkClient::DeleteTimer(const PVR_TIMER &timer)
   parse_timer_hash(timer.strDirectory, timer_id, schedule_id);
 
   bool cancel_series = true;
-  if (timer.bIsRepeating)
+  if (timer.iWeekdays > 0) // repeating timer?
   {
       //show dialog and ask: cancel series or just this episode
       CDialogDeleteTimer vWindow(XBMC, GUI, cancel_series);

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -621,6 +621,12 @@ bool CanSeekStream(void)
 
 //recording timers functions
 
+PVR_ERROR GetTimerTypes(PVR_TIMER_TYPE types[], int *size)
+{
+  /* TODO: Implement this to get support for the timer features introduced with PVR API 1.9.7 */
+  return PVR_ERROR_NOT_IMPLEMENTED;
+}
+
 int GetTimersAmount(void)
 {
   if (dvblinkclient)
@@ -631,6 +637,7 @@ int GetTimersAmount(void)
 
 PVR_ERROR GetTimers(ADDON_HANDLE handle)
 {
+  /* TODO: Change implementation to get support for the timer features introduced with PVR API 1.9.7 */
   if (dvblinkclient)
     return dvblinkclient->GetTimers(handle); 
 
@@ -645,8 +652,9 @@ PVR_ERROR AddTimer(const PVR_TIMER &timer)
   return PVR_ERROR_FAILED;
 }
 
-PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete)
+PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete, bool /*bDeleteScheduled*/)
 {
+  /* TODO: Change implementation to support bDeleteScheduled (introduced with PVR API 1.9.7 */
   if (dvblinkclient)
     return dvblinkclient->DeleteTimer(timer);
 


### PR DESCRIPTION
For, J***\* PVR Addon API will be bumped to version 1.9.7 to introduce a couple of new features and enhancements for timers (esp. official series recording support). => https://github.com/xbmc/xbmc/pull/7079

This PR will ensure compatibility with and add minimalistic support for PVR addon API 1.9.7. Even if the maintainers of this addon will do nothing except merging this PR and bump the addon version in Kodi, the addon will still be usable in J***\* and not loose any functionality compared to Isengard, but it will not profit from the new features. For the latter, every addon maintainer must do the respective changes on his own.
