### PR TITLE
Isengard - [debian packaging] don't use LTO linking

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -13,7 +13,7 @@
 	dh $@ 
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1 -DUSE_LTO=1
+	dh_auto_configure -- -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1
 
 override_dh_strip:
 	dh_strip -pkodi-pvr-dvblink --dbg-package=kodi-pvr-dvblink-dbg


### PR DESCRIPTION
backport of https://github.com/kodi-pvr/pvr.dvblink/pull/23
