### PR TITLE
Update to PVR addon API v4.0.0

### DIFF
--- a/pvr.dvblink/addon.xml.in
+++ b/pvr.dvblink/addon.xml.in
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.dvblink"
-  version="1.11.4"
+  version="1.11.5"
   name="DVBLink PVR Client"
   provider-name="DVBLogic">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="3.0.0"/>
+    <import addon="xbmc.pvr" version="4.0.0"/>
   </requires>
   <extension
     point="xbmc.pvrclient"

--- a/pvr.dvblink/changelog.txt
+++ b/pvr.dvblink/changelog.txt
@@ -1,3 +1,6 @@
+[B]Version 1.11.5[/B]
+Updated to PVR API v4.0.0
+
 [B]Version 1.11.4[/B]
 Updated to PVR API v3.0.0 (API 1.9.7 Compatibility Mode)
 

--- a/src/DVBLinkClient.cpp
+++ b/src/DVBLinkClient.cpp
@@ -341,7 +341,8 @@ PVR_ERROR DVBLinkClient::GetTimers(ADDON_HANDLE handle)
     XBMC->QueueNotification(QUEUE_INFO, XBMC->GetLocalizedString(32007), recordings.size());
   }
 
-  for (size_t i=0; i < recordings.size(); i++)
+  unsigned int index = PVR_TIMER_NO_CLIENT_INDEX + 1;
+  for (size_t i=0; i < recordings.size(); i++, index++)
   {
     Recording* rec = recordings[i];
 
@@ -352,7 +353,7 @@ PVR_ERROR DVBLinkClient::GetTimers(ADDON_HANDLE handle)
     xbmcTimer.iTimerType = PVR_TIMER_TYPE_NONE;
 
     //fake index
-    xbmcTimer.iClientIndex = i;
+    xbmcTimer.iClientIndex = index;
     //misuse strDirectory to keep id of the timer
     std::string timer_hash = make_timer_hash(rec->GetID(), rec->GetScheduleID());
     PVR_STRCPY(xbmcTimer.strDirectory, timer_hash.c_str());
@@ -423,7 +424,7 @@ PVR_ERROR DVBLinkClient::AddTimer(const PVR_TIMER &timer)
     DVBLinkRemoteStatusCode status;
     AddScheduleRequest * addScheduleRequest = NULL;
     std::string channelId = m_channelMap[timer.iClientChannelUid]->GetID();
-    if (timer.iEpgUid != -1)
+    if (timer.iEpgUid != PVR_TIMER_NO_EPG_UID)
     {
         bool record_series = false;
         bool newOnly = true;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -652,9 +652,8 @@ PVR_ERROR AddTimer(const PVR_TIMER &timer)
   return PVR_ERROR_FAILED;
 }
 
-PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete, bool /*bDeleteScheduled*/)
+PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete)
 {
-  /* TODO: Change implementation to support bDeleteScheduled (introduced with PVR API 1.9.7 */
   if (dvblinkclient)
     return dvblinkclient->DeleteTimer(timer);
 


### PR DESCRIPTION
This PR implements all changes needed to properly support PVR Addon API v4.0.0, including a PVR addon micro version bump.

Details can be found here: https://github.com/xbmc/xbmc/pull/8005
