### PR TITLE
Update to PVR addon API v4.1.0

### DIFF
--- a/pvr.dvblink/addon.xml.in
+++ b/pvr.dvblink/addon.xml.in
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.dvblink"
-  version="1.11.5"
+  version="1.11.6"
   name="DVBLink PVR Client"
   provider-name="DVBLogic">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="4.0.0"/>
+    <import addon="xbmc.pvr" version="4.1.0"/>
   </requires>
   <extension
     point="xbmc.pvrclient"

--- a/pvr.dvblink/changelog.txt
+++ b/pvr.dvblink/changelog.txt
@@ -1,3 +1,6 @@
+[B]Version 1.11.6[/B]
+Updated to PVR API v4.1.0
+
 [B]Version 1.11.5[/B]
 Updated to PVR API v4.0.0
 

--- a/src/DVBLinkClient.cpp
+++ b/src/DVBLinkClient.cpp
@@ -1080,6 +1080,8 @@ PVR_ERROR DVBLinkClient::GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL
         else
           broadcast.iGenreSubType = genre_subtype;
 
+        broadcast.iFlags              = EPG_TAG_FLAG_UNDEFINED;
+        
         PVR->TransferEpgEntry(handle, &broadcast);
       }
     }


### PR DESCRIPTION
This PR implements all changes needed to properly support PVR Addon API v4.1.0, including a PVR addon micro version bump.

Details can be found here: xbmc/xbmc#8075
