### PR TITLE
pvr.dvblink version 2.2.0 (jarvis)

### DIFF
--- a/lib/libdvblinkremote/channel.cpp
+++ b/lib/libdvblinkremote/channel.cpp
@@ -122,7 +122,7 @@ bool GetChannelsResponseSerializer::ReadObject(ChannelList& object, const std::s
 {
   tinyxml2::XMLDocument& doc = GetXmlDocument();
     
-  if (doc.Parse(xml.c_str()) == tinyxml2::XML_NO_ERROR) {
+  if (doc.Parse(xml.c_str()) == tinyxml2::XML_SUCCESS) {
     tinyxml2::XMLElement* elRoot = doc.FirstChildElement("channels");
     GetChannelsResponseXmlDataDeserializer* xmlDataDeserializer = new GetChannelsResponseXmlDataDeserializer(*this, object);
     elRoot->Accept(xmlDataDeserializer);

--- a/lib/libdvblinkremote/dvblinkremotecommunication.cpp
+++ b/lib/libdvblinkremote/dvblinkremotecommunication.cpp
@@ -21,6 +21,7 @@
  *
  ***************************************************************************/
 
+#include <cstdarg>
 #include "dvblinkremoteconnection.h"
 #include "xml_object_serializer.h"
 #include "generic_response.h"

--- a/lib/libdvblinkremote/epg.cpp
+++ b/lib/libdvblinkremote/epg.cpp
@@ -189,7 +189,7 @@ bool EpgSearchResponseSerializer::ReadObject(EpgSearchResult& object, const std:
 {
   tinyxml2::XMLDocument& doc = GetXmlDocument();
     
-  if (doc.Parse(xml.c_str()) == tinyxml2::XML_NO_ERROR) {
+  if (doc.Parse(xml.c_str()) == tinyxml2::XML_SUCCESS) {
     tinyxml2::XMLElement* elRoot = doc.FirstChildElement("epg_searcher");
     ChannelEpgXmlDataDeserializer* xmlDataDeserializer = new ChannelEpgXmlDataDeserializer(*this, object);
     elRoot->Accept(xmlDataDeserializer);

--- a/lib/libdvblinkremote/favorites.cpp
+++ b/lib/libdvblinkremote/favorites.cpp
@@ -118,7 +118,7 @@ bool ChannelFavoritesSerializer::ReadObject(ChannelFavorites& object, const std:
 {
     tinyxml2::XMLDocument& doc = GetXmlDocument();
 
-    if (doc.Parse(xml.c_str()) == tinyxml2::XML_NO_ERROR) {
+    if (doc.Parse(xml.c_str()) == tinyxml2::XML_SUCCESS) {
         tinyxml2::XMLElement* elRoot = doc.FirstChildElement("favorites");
         GetFavoritesResponseXmlDataDeserializer* xmlDataDeserializer = new GetFavoritesResponseXmlDataDeserializer(*this, object);
         elRoot->Accept(xmlDataDeserializer);

--- a/lib/libdvblinkremote/generic_response.cpp
+++ b/lib/libdvblinkremote/generic_response.cpp
@@ -74,7 +74,7 @@ bool GenericResponseSerializer::ReadObject(GenericResponse& object, const std::s
 {
   tinyxml2::XMLDocument& doc = GetXmlDocument();
     
-  if (doc.Parse(xml.c_str()) == tinyxml2::XML_NO_ERROR) {
+  if (doc.Parse(xml.c_str()) == tinyxml2::XML_SUCCESS) {
     tinyxml2::XMLElement* elRoot = doc.FirstChildElement("response");
     int statusCode = Util::GetXmlFirstChildElementTextAsInt(elRoot, "status_code");
 

--- a/lib/libdvblinkremote/parental_lock.cpp
+++ b/lib/libdvblinkremote/parental_lock.cpp
@@ -95,7 +95,7 @@ bool ParentalStatusSerializer::ReadObject(ParentalStatus& object, const std::str
 {
   tinyxml2::XMLDocument& doc = GetXmlDocument();
     
-  if (doc.Parse(xml.c_str()) == tinyxml2::XML_NO_ERROR) {
+  if (doc.Parse(xml.c_str()) == tinyxml2::XML_SUCCESS) {
     tinyxml2::XMLElement* elRoot = doc.FirstChildElement("parental_status");
     object.IsEnabled = Util::GetXmlFirstChildElementTextAsBoolean(elRoot, "is_enabled");
     return true;

--- a/lib/libdvblinkremote/playback_object.cpp
+++ b/lib/libdvblinkremote/playback_object.cpp
@@ -136,7 +136,7 @@ bool GetPlaybackObjectResponseSerializer::ReadObject(GetPlaybackObjectResponse& 
 {
   tinyxml2::XMLDocument& doc = GetXmlDocument();
     
-  if (doc.Parse(xml.c_str()) == tinyxml2::XML_NO_ERROR) {
+  if (doc.Parse(xml.c_str()) == tinyxml2::XML_SUCCESS) {
     tinyxml2::XMLElement* elRoot = doc.FirstChildElement("object");
     
     if (HasChildElement(*elRoot, "containers")) 

--- a/lib/libdvblinkremote/recording.cpp
+++ b/lib/libdvblinkremote/recording.cpp
@@ -106,7 +106,7 @@ bool GetRecordingsResponseSerializer::ReadObject(RecordingList& object, const st
 {
   tinyxml2::XMLDocument& doc = GetXmlDocument();
     
-  if (doc.Parse(xml.c_str()) == tinyxml2::XML_NO_ERROR) {
+  if (doc.Parse(xml.c_str()) == tinyxml2::XML_SUCCESS) {
     tinyxml2::XMLElement* elRoot = doc.FirstChildElement("recordings");
     GetRecordingsResponseXmlDataDeserializer* xmlDataDeserializer = new GetRecordingsResponseXmlDataDeserializer(*this, object);
     elRoot->Accept(xmlDataDeserializer);

--- a/lib/libdvblinkremote/recording_settings.cpp
+++ b/lib/libdvblinkremote/recording_settings.cpp
@@ -81,13 +81,13 @@ bool RecordingSettingsSerializer::ReadObject(RecordingSettings& object, const st
 {
   tinyxml2::XMLDocument& doc = GetXmlDocument();
     
-  if (doc.Parse(xml.c_str()) == tinyxml2::XML_NO_ERROR) {
+  if (doc.Parse(xml.c_str()) == tinyxml2::XML_SUCCESS) {
     tinyxml2::XMLElement* elRoot = doc.FirstChildElement("recording_settings");
     object.TimeMarginBeforeScheduledRecordings = Util::GetXmlFirstChildElementTextAsInt(elRoot, "before_margin");
     object.TimeMarginAfterScheduledRecordings = Util::GetXmlFirstChildElementTextAsInt(elRoot, "after_margin");
     object.RecordingPath = Util::GetXmlFirstChildElementText(elRoot, "recording_path");
-    object.TotalSpace = Util::GetXmlFirstChildElementTextAsLong(elRoot, "total_space");
-    object.AvailableSpace = Util::GetXmlFirstChildElementTextAsLong(elRoot, "avail_space");
+    object.TotalSpace = Util::GetXmlFirstChildElementTextAsLongLong(elRoot, "total_space");
+    object.AvailableSpace = Util::GetXmlFirstChildElementTextAsLongLong(elRoot, "avail_space");
     return true;
   }
 

--- a/lib/libdvblinkremote/response.h
+++ b/lib/libdvblinkremote/response.h
@@ -1350,12 +1350,12 @@ namespace dvblinkremote {
     /**
       * The total space in KB.
       */
-    long TotalSpace;
+    long long TotalSpace;
 
     /**
       * The available space in KB. 
       */
-    long AvailableSpace;
+    long long AvailableSpace;
   };
 
   class ChannelFavorite

--- a/lib/libdvblinkremote/scheduling.cpp
+++ b/lib/libdvblinkremote/scheduling.cpp
@@ -415,7 +415,7 @@ bool GetSchedulesResponseSerializer::ReadObject(StoredSchedules& object, const s
 {
   tinyxml2::XMLDocument& doc = GetXmlDocument();
     
-  if (doc.Parse(xml.c_str()) == tinyxml2::XML_NO_ERROR) {
+  if (doc.Parse(xml.c_str()) == tinyxml2::XML_SUCCESS) {
     tinyxml2::XMLElement* elRoot = doc.FirstChildElement("schedules");
     GetSchedulesResponseXmlDataDeserializer* xmlDataDeserializer = new GetSchedulesResponseXmlDataDeserializer(*this, object);
     elRoot->Accept(xmlDataDeserializer);

--- a/lib/libdvblinkremote/server_info.cpp
+++ b/lib/libdvblinkremote/server_info.cpp
@@ -63,7 +63,7 @@ bool ServerInfoSerializer::ReadObject(ServerInfo& object, const std::string& xml
 {
   tinyxml2::XMLDocument& doc = GetXmlDocument();
     
-  if (doc.Parse(xml.c_str()) == tinyxml2::XML_NO_ERROR) {
+  if (doc.Parse(xml.c_str()) == tinyxml2::XML_SUCCESS) {
     tinyxml2::XMLElement* elRoot = doc.FirstChildElement("server_info");
     object.install_id_ = Util::GetXmlFirstChildElementText(elRoot, "install_id");
     object.server_id_ = Util::GetXmlFirstChildElementText(elRoot, "server_id");

--- a/lib/libdvblinkremote/stream.cpp
+++ b/lib/libdvblinkremote/stream.cpp
@@ -74,7 +74,7 @@ bool StreamResponseSerializer::ReadObject(Stream& object, const std::string& xml
 {
   tinyxml2::XMLDocument& doc = GetXmlDocument();
     
-  if (doc.Parse(xml.c_str()) == tinyxml2::XML_NO_ERROR) {
+  if (doc.Parse(xml.c_str()) == tinyxml2::XML_SUCCESS) {
     tinyxml2::XMLElement* elRoot = doc.FirstChildElement("stream");
     long channelHandle = Util::GetXmlFirstChildElementTextAsLong(elRoot, "channel_handle");
     std::string url = Util::GetXmlFirstChildElementText(elRoot, "url");

--- a/lib/libdvblinkremote/streaming_capabilities.cpp
+++ b/lib/libdvblinkremote/streaming_capabilities.cpp
@@ -83,7 +83,7 @@ bool StreamingCapabilitiesSerializer::ReadObject(StreamingCapabilities& object, 
 {
   tinyxml2::XMLDocument& doc = GetXmlDocument();
     
-  if (doc.Parse(xml.c_str()) == tinyxml2::XML_NO_ERROR) {
+  if (doc.Parse(xml.c_str()) == tinyxml2::XML_SUCCESS) {
     tinyxml2::XMLElement* elRoot = doc.FirstChildElement("streaming_caps");
     object.SupportedProtocols = Util::GetXmlFirstChildElementTextAsInt(elRoot, "protocols");
     object.SupportedTranscoders = Util::GetXmlFirstChildElementTextAsInt(elRoot, "transcoders");

--- a/lib/libdvblinkremote/util.cpp
+++ b/lib/libdvblinkremote/util.cpp
@@ -34,6 +34,7 @@ bool Util::from_string(T& t, const std::string& s, std::ios_base& (*f)(std::ios_
 
 template bool Util::from_string<int>(int& t, const std::string& s, std::ios_base& (*f)(std::ios_base&));
 template bool Util::from_string<long>(long& t, const std::string& s, std::ios_base& (*f)(std::ios_base&));
+template bool Util::from_string<long long>(long long& t, const std::string& s, std::ios_base& (*f)(std::ios_base&));
 
 template <class T>
 bool Util::to_string(const T& t, std::string& s)
@@ -57,6 +58,11 @@ bool Util::ConvertToInt(const std::string& s, int& value)
 bool Util::ConvertToLong(const std::string& s, long& value) 
 {
   return from_string<long>(value, s, std::dec);
+}
+
+bool Util::ConvertToLongLong(const std::string& s, long long& value) 
+{
+  return from_string<long long>(value, s, std::dec);
 }
 
 bool Util::ConvertToString(const int& value, std::string& s) 
@@ -185,6 +191,24 @@ long Util::GetXmlFirstChildElementTextAsLong(const tinyxml2::XMLElement* parentE
   }
 
   if (s && !Util::ConvertToLong(s, value))
+  {
+    value = -1;
+  }
+
+  return value;
+}
+
+long long Util::GetXmlFirstChildElementTextAsLongLong(const tinyxml2::XMLElement* parentElement, const char* name) 
+{
+  const tinyxml2::XMLElement* el = parentElement->FirstChildElement(name);
+  const char* s = "-1";
+  long long value;
+
+  if (el != NULL && el->GetText()) {
+    s = el->GetText();
+  }
+
+  if (s && !Util::ConvertToLongLong(s, value))
   {
     value = -1;
   }

--- a/lib/libdvblinkremote/util.h
+++ b/lib/libdvblinkremote/util.h
@@ -34,6 +34,7 @@ namespace dvblinkremote {
   public:
     static bool ConvertToInt(const std::string& s, int& value);
     static bool ConvertToLong(const std::string& s, long& value);
+    static bool ConvertToLongLong(const std::string& s, long long& value);
     static bool ConvertToString(const int& value, std::string&);
     static bool ConvertToString(const unsigned int& value, std::string&);
     static bool ConvertToString(const long& value, std::string&);
@@ -47,6 +48,7 @@ namespace dvblinkremote {
     static const char* GetXmlFirstChildElementText(const tinyxml2::XMLElement* parentElement, const char* name);
     static int GetXmlFirstChildElementTextAsInt(const tinyxml2::XMLElement* parentElement, const char* name);
     static long GetXmlFirstChildElementTextAsLong(const tinyxml2::XMLElement* parentElement, const char* name);
+    static long long GetXmlFirstChildElementTextAsLongLong(const tinyxml2::XMLElement* parentElement, const char* name);
     static bool GetXmlFirstChildElementTextAsBoolean(const tinyxml2::XMLElement* parentElement, const char* name);
 
   private:

--- a/pvr.dvblink/addon.xml.in
+++ b/pvr.dvblink/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.dvblink"
-  version="2.1.10"
+  version="2.2.0"
   name="DVBLink PVR Client"
   provider-name="DVBLogic">
   <requires>

--- a/pvr.dvblink/changelog.txt
+++ b/pvr.dvblink/changelog.txt
@@ -1,3 +1,9 @@
+[B]Version 2.2.0[/B]
+Fixed: Crash on startup with search timers
+Fixed: Incorrect disk space display if disk size is more than 2TB
+Fixed: Doesn't build with tinyxml2 4.x
+Added: transcoded recordings playback in DVBLink v6
+ 
 [B]Version 2.1.10[/B]
 Updated: language files from Transifex
 

--- a/src/DVBLinkClient.cpp
+++ b/src/DVBLinkClient.cpp
@@ -695,7 +695,7 @@ int DVBLinkClient::GetSchedules(ADDON_HANDLE handle, const RecordingList& record
       strncpy(timer.strTitle, epg_schedules[i]->program_name_.c_str(), sizeof(timer.strTitle) - 1);
 
       if (schedule_to_timer_map.find(epg_schedules[i]->GetID()) != schedule_to_timer_map.end() &&
-        schedule_to_timer_map[epg_schedules[i]->GetID()].size() > 0)
+        !schedule_to_timer_map[epg_schedules[i]->GetID()].empty())
       {
         timer.startTime = schedule_to_timer_map[epg_schedules[i]->GetID()].at(0)->GetProgram().GetStartTime();
         timer.endTime = timer.startTime + schedule_to_timer_map[epg_schedules[i]->GetID()].at(0)->GetProgram().GetDuration();
@@ -726,7 +726,7 @@ int DVBLinkClient::GetSchedules(ADDON_HANDLE handle, const RecordingList& record
     //misuse strDirectory to keep id of the timer
     PVR_STRCPY(timer.strDirectory, bp_schedules[i]->GetID().c_str());
     timer.iClientIndex = kodi_idx;
-    if (bp_schedules[i]->GetChannelID().size() > 0)
+    if (!bp_schedules[i]->GetChannelID().size().empty())
       timer.iClientChannelUid = GetInternalUniqueIdFromChannelId(bp_schedules[i]->GetChannelID());
     else
       timer.iClientChannelUid = PVR_TIMER_ANY_CHANNEL;
@@ -738,7 +738,7 @@ int DVBLinkClient::GetSchedules(ADDON_HANDLE handle, const RecordingList& record
     strncpy(timer.strEpgSearchString, bp_schedules[i]->GetKeyphrase().c_str(), sizeof(timer.strEpgSearchString) - 1);
 
     if (schedule_to_timer_map.find(bp_schedules[i]->GetID()) != schedule_to_timer_map.end() &&
-      schedule_to_timer_map[bp_schedules[i]->GetID()].size() > 0)
+      !schedule_to_timer_map[bp_schedules[i]->GetID()].empty())
     {
       timer.startTime = schedule_to_timer_map[bp_schedules[i]->GetID()].at(0)->GetProgram().GetStartTime();
       timer.endTime = timer.startTime + schedule_to_timer_map[bp_schedules[i]->GetID()].at(0)->GetProgram().GetDuration();

--- a/src/DVBLinkClient.h
+++ b/src/DVBLinkClient.h
@@ -132,7 +132,8 @@ public:
   time_t GetPlayingTime();
   time_t GetBufferTimeStart();
   time_t GetBufferTimeEnd();
-  bool GetRecordingURL(const char* recording_id, std::string& url);
+  bool GetRecordingURL(const char* recording_id, std::string& url, bool use_transcoder, int width,
+    int height, int bitrate, std::string audiotrack);
 
 private:
   bool DoEPGSearch(dvblinkremote::EpgSearchResult& epgSearchResult, const std::string& channelId, const long startTime,
@@ -185,6 +186,7 @@ private:
   bool setting_margins_supported_;
   bool favorites_supported_;
   bool transcoding_supported_;
+  bool transcoding_recordings_supported_;
   dvblinkremote::ChannelFavorites channel_favorites_;
   std::map<std::string, int> inverse_channel_map_;
   bool no_group_single_rec_;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -736,7 +736,7 @@ bool OpenRecordedStream(const PVR_RECORDING &recording)
 
   bool ret_val = false;
   std::string url;
-  if (dvblinkclient->GetRecordingURL(recording.strRecordingId, url))
+  if (dvblinkclient->GetRecordingURL(recording.strRecordingId, url, g_bUseTranscoding, g_iWidth, g_iHeight, g_iBitrate, g_szAudiotrack))
   {
     recording_streamer = new RecordingStreamer(XBMC, g_szClientname, g_szHostname, g_lPort, g_szUsername, g_szPassword);
     if (recording_streamer->OpenRecordedStream(recording.strRecordingId, url))


### PR DESCRIPTION
Fixed: Crash on startup with search timers
Fixed: Incorrect disk space display if disk size is more than 2TB
Fixed: Doesn't build with tinyxml2 4.x
Added: transcoded recordings playback in DVBLink v6
