### PR TITLE
pvr.dvblink (krypton) version 3.4.0

### DIFF
--- a/lib/libdvblinkremote/CMakeLists.txt
+++ b/lib/libdvblinkremote/CMakeLists.txt
@@ -27,6 +27,7 @@ SET(SOURCES channel.cpp
             stream.cpp
             streaming_capabilities.cpp
             stream_request.cpp
+            timeshift.cpp
             transcoded_video_stream_request.cpp
             transcoding_options.cpp
             util.cpp

--- a/lib/libdvblinkremote/channel.cpp
+++ b/lib/libdvblinkremote/channel.cpp
@@ -28,7 +28,7 @@
 using namespace dvblinkremote;
 using namespace dvblinkremoteserialization;
 
-Channel::Channel(const std::string& id, const long dvbLinkId, const std::string& name, const DVBLinkChannelType type, 
+Channel::Channel(const std::string& id, const std::string& dvbLinkId, const std::string& name, const DVBLinkChannelType type, 
                  const std::string& logo_url, const int number, const int subNumber) 
   : m_id(id), 
     m_dvbLinkId(dvbLinkId), 
@@ -65,7 +65,7 @@ std::string& Channel::GetID()
   return m_id;
 }
 
-long Channel::GetDvbLinkID() 
+std::string& Channel::GetDvbLinkID() 
 {
   return m_dvbLinkId;
 }
@@ -150,7 +150,7 @@ bool GetChannelsResponseSerializer::GetChannelsResponseXmlDataDeserializer::Visi
 {
   if (strcmp(element.Name(), "channel") == 0) 
   {     
-    long channelDvbLinkId = Util::GetXmlFirstChildElementTextAsLong(&element, "channel_dvblink_id");
+    std::string channelDvbLinkId = Util::GetXmlFirstChildElementText(&element, "channel_dvblink_id");
     std::string channelId = Util::GetXmlFirstChildElementText(&element, "channel_id");
     std::string channelName = Util::GetXmlFirstChildElementText(&element, "channel_name");
     int channelNumber = Util::GetXmlFirstChildElementTextAsInt(&element, "channel_number");

--- a/lib/libdvblinkremote/dvblinkremote.h
+++ b/lib/libdvblinkremote/dvblinkremote.h
@@ -197,6 +197,16 @@ namespace dvblinkremote
   const std::string DVBLINK_REMOTE_GET_SERVER_INFO_CMD = "get_server_info";
 
   /**
+  * A constant string representing the DVBLink command for getting timeshift statistics.
+  */
+  const std::string DVBLINK_REMOTE_GET_TIMESHIFT_STATS_CMD = "timeshift_get_stats";
+
+  /**
+  * A constant string representing the DVBLink command for timeshift seek.
+  */
+  const std::string DVBLINK_REMOTE_TIMESHIFT_SEEK_CMD = "timeshift_seek";
+
+  /**
     * A constant string representing a Real Time Transport Protocol stream type for Android devices.
     */
   const std::string DVBLINK_REMOTE_STREAM_TYPE_ANDROID = "rtp";
@@ -487,6 +497,21 @@ namespace dvblinkremote
     * @return                   A DVBLinkRemoteStatusCode representing the status of the executed method.
     */
     virtual DVBLinkRemoteStatusCode GetServerInfo(const GetServerInfoRequest& request, ServerInfo& response, std::string* err_str) = 0;
+
+    /**
+    * Gets timeshift buffer statistics for a playing stream
+    * @param[in]      request   A constant GetTimeshiftStatsRequest reference representing the playing channel handle.
+    * @param[in,out]  response  A TimeshiftStats reference that will be populated with timeshift stats.
+    * @return                   A DVBLinkRemoteStatusCode representing the status of the executed method.
+    */
+    virtual DVBLinkRemoteStatusCode GetTimeshiftStats(const GetTimeshiftStatsRequest& request, TimeshiftStats& response, std::string* err_str) = 0;
+
+    /**
+    * Seeks in timeshift buffer for a playing stream
+    * @param[in]      request   A constant TimeshiftSeekRequest reference representing timeshift seek parameters.
+    * @return                   A DVBLinkRemoteStatusCode representing the status of the executed method.
+    */
+    virtual DVBLinkRemoteStatusCode TimeshiftSeek(const TimeshiftSeekRequest& request, std::string* err_str) = 0;
 
     /**
       * Gets a description of the last occured error.

--- a/lib/libdvblinkremote/dvblinkremotecommunication.cpp
+++ b/lib/libdvblinkremote/dvblinkremotecommunication.cpp
@@ -238,6 +238,22 @@ DVBLinkRemoteStatusCode DVBLinkRemoteCommunication::GetServerInfo(const GetServe
     return GetData(DVBLINK_REMOTE_GET_SERVER_INFO_CMD, request, response, err_str);
 }
 
+DVBLinkRemoteStatusCode DVBLinkRemoteCommunication::GetTimeshiftStats(const GetTimeshiftStatsRequest& request, TimeshiftStats& response, std::string* err_str)
+{
+  return GetData(DVBLINK_REMOTE_GET_TIMESHIFT_STATS_CMD, request, response, err_str);
+}
+
+DVBLinkRemoteStatusCode DVBLinkRemoteCommunication::TimeshiftSeek(const TimeshiftSeekRequest& request, std::string* err_str)
+{
+  Response* response = new Response();
+
+  DVBLinkRemoteStatusCode status = GetData(DVBLINK_REMOTE_TIMESHIFT_SEEK_CMD, request, *response, err_str);
+
+  delete response;
+  return status;
+}
+
+
 std::string DVBLinkRemoteCommunication::GetUrl()
 {
   char buffer[2000];

--- a/lib/libdvblinkremote/dvblinkremoteconnection.h
+++ b/lib/libdvblinkremote/dvblinkremoteconnection.h
@@ -66,6 +66,8 @@ namespace dvblinkremote
     DVBLinkRemoteStatusCode SetRecordingSettings(const SetRecordingSettingsRequest& request, std::string* err_str);
     DVBLinkRemoteStatusCode GetFavorites(const GetFavoritesRequest& request, ChannelFavorites& response, std::string* err_str);
     DVBLinkRemoteStatusCode GetServerInfo(const GetServerInfoRequest& request, ServerInfo& response, std::string* err_str);
+    DVBLinkRemoteStatusCode GetTimeshiftStats(const GetTimeshiftStatsRequest& request, TimeshiftStats& response, std::string* err_str);
+    DVBLinkRemoteStatusCode TimeshiftSeek(const TimeshiftSeekRequest& request, std::string* err_str);
 
   private:
     dvblinkremotehttp::HttpClient& m_httpClient;

--- a/lib/libdvblinkremote/request.h
+++ b/lib/libdvblinkremote/request.h
@@ -206,14 +206,14 @@ namespace dvblinkremote {
     /**
       * Initializes a new instance of the dvblinkremote::StreamRequest class.
       * @param serverAddress a constant string reference representing the DVBLink server address.
-      * @param dvbLinkChannelId a constant long representing the DVBLink channel identifier.
+      * @param dvbLinkChannelId a constant string representing the DVBLink channel identifier.
       * @param clientId a constant string reference representing the unique identification string of the client. 
       * @param streamType a constant string reference representing the stream type for the stream request. 
       * \remark \p serverAddress is the IP address/server network name of the DVBLink server. 
       * \remark \p clientId should be the same across all DVBLink Client API calls from a given client. 
       * It can be a uuid for example or id/mac of the client device.
       */
-    StreamRequest(const std::string& serverAddress, const long dvbLinkChannelId, const std::string& clientId, const std::string& streamType);
+    StreamRequest(const std::string& serverAddress, const std::string& dvbLinkChannelId, const std::string& clientId, const std::string& streamType);
 
     /**
       * Pure virtual destructor for cleaning up allocated memory.
@@ -231,7 +231,7 @@ namespace dvblinkremote {
       * Gets the DVBLink channel identifier for the stream request.
       * @return Stream request channel identifier
       */
-    long GetDVBLinkChannelID();
+    std::string& GetDVBLinkChannelID();
 
     /**
       * Gets the unique identification string of the client for the stream request.
@@ -259,7 +259,7 @@ namespace dvblinkremote {
     /**
       * DVBLink channel identifier.
       */
-    long m_dvbLinkChannelId;
+    std::string m_dvbLinkChannelId;
 
     /**
       * The unique identification string of the client.
@@ -381,7 +381,7 @@ namespace dvblinkremote {
     /**
       * Initializes a new instance of the dvblinkremote::TranscodedVideoStreamRequest class.
       * @param serverAddress a constant string reference representing the DVBLink server address.
-      * @param dvbLinkChannelId a constant long representing the DVBLink channel identifier.
+      * @param dvbLinkChannelId a constant string representing the DVBLink channel identifier.
       * @param clientId a constant string reference representing the unique identification string of the client. 
       * @param transcodingOptions a dvblinkremote::TranscodingOptions instance reference representing the transcoding options
       * of the stream request. 
@@ -390,7 +390,7 @@ namespace dvblinkremote {
       * \remark \p clientId should be the same across all DVBLink Client API calls from a given client. 
       * It can be a uuid for example or id/mac of the client device.
       */
-    TranscodedVideoStreamRequest(const std::string& serverAddress, const long dvbLinkChannelId, const std::string& clientId, TranscodingOptions& transcodingOptions, const std::string& streamType);
+    TranscodedVideoStreamRequest(const std::string& serverAddress, const std::string& dvbLinkChannelId, const std::string& clientId, TranscodingOptions& transcodingOptions, const std::string& streamType);
 
     /**
       * Destructor for cleaning up allocated memory.
@@ -421,7 +421,7 @@ namespace dvblinkremote {
     /**
       * Initializes a new instance of the dvblinkremote::RealTimeTransportProtocolStreamRequest class.
       * @param serverAddress a constant string reference representing the DVBLink server address.
-      * @param dvbLinkChannelId a constant long representing the DVBLink channel identifier.
+      * @param dvbLinkChannelId a constant string representing the DVBLink channel identifier.
       * @param clientId a constant string reference representing the unique identification string of the client. 
       * @param transcodingOptions a dvblinkremote::TranscodingOptions instance reference representing the transcoding options
       * of the stream request. 
@@ -429,7 +429,7 @@ namespace dvblinkremote {
       * \remark \p clientId should be the same across all DVBLink Client API calls from a given client. 
       * It can be a uuid for example or id/mac of the client device.
       */
-    RealTimeTransportProtocolStreamRequest(const std::string& serverAddress, const long dvbLinkChannelId, const std::string& clientId, TranscodingOptions& transcodingOptions);
+    RealTimeTransportProtocolStreamRequest(const std::string& serverAddress, const std::string& dvbLinkChannelId, const std::string& clientId, TranscodingOptions& transcodingOptions);
 
     /**
       * Destructor for cleaning up allocated memory.
@@ -448,7 +448,7 @@ namespace dvblinkremote {
 	  /**
 	  * Initializes a new instance of the dvblinkremote::MP4StreamRequest class.
 	  * @param serverAddress a constant string reference representing the DVBLink server address.
-	  * @param dvbLinkChannelId a constant long representing the DVBLink channel identifier.
+	  * @param dvbLinkChannelId a constant string representing the DVBLink channel identifier.
 	  * @param clientId a constant string reference representing the unique identification string of the client.
 	  * @param transcodingOptions a dvblinkremote::TranscodingOptions instance reference representing the transcoding options
 	  * of the stream request.
@@ -456,7 +456,7 @@ namespace dvblinkremote {
 	  * \remark \p clientId should be the same across all DVBLink Client API calls from a given client.
 	  * It can be a uuid for example or id/mac of the client device.
 	  */
-	  MP4StreamRequest(const std::string& serverAddress, const long dvbLinkChannelId, const std::string& clientId, TranscodingOptions& transcodingOptions);
+	  MP4StreamRequest(const std::string& serverAddress, const std::string& dvbLinkChannelId, const std::string& clientId, TranscodingOptions& transcodingOptions);
 
 	  /**
 	  * Destructor for cleaning up allocated memory.
@@ -475,7 +475,7 @@ namespace dvblinkremote {
       /**
       * Initializes a new instance of the dvblinkremote::H264TSStreamRequest class.
       * @param serverAddress a constant string reference representing the DVBLink server address.
-      * @param dvbLinkChannelId a constant long representing the DVBLink channel identifier.
+      * @param dvbLinkChannelId a constant string representing the DVBLink channel identifier.
       * @param clientId a constant string reference representing the unique identification string of the client.
       * @param transcodingOptions a dvblinkremote::TranscodingOptions instance reference representing the transcoding options
       * of the stream request.
@@ -483,7 +483,7 @@ namespace dvblinkremote {
       * \remark \p clientId should be the same across all DVBLink Client API calls from a given client.
       * It can be a uuid for example or id/mac of the client device.
       */
-      H264TSStreamRequest(const std::string& serverAddress, const long dvbLinkChannelId, const std::string& clientId, TranscodingOptions& transcodingOptions);
+      H264TSStreamRequest(const std::string& serverAddress, const std::string& dvbLinkChannelId, const std::string& clientId, TranscodingOptions& transcodingOptions);
 
       /**
       * Destructor for cleaning up allocated memory.
@@ -502,7 +502,7 @@ namespace dvblinkremote {
       /**
       * Initializes a new instance of the dvblinkremote::H264TSStreamRequest class.
       * @param serverAddress a constant string reference representing the DVBLink server address.
-      * @param dvbLinkChannelId a constant long representing the DVBLink channel identifier.
+      * @param dvbLinkChannelId a constant string representing the DVBLink channel identifier.
       * @param clientId a constant string reference representing the unique identification string of the client.
       * @param transcodingOptions a dvblinkremote::TranscodingOptions instance reference representing the transcoding options
       * of the stream request.
@@ -510,7 +510,7 @@ namespace dvblinkremote {
       * \remark \p clientId should be the same across all DVBLink Client API calls from a given client.
       * It can be a uuid for example or id/mac of the client device.
       */
-      H264TSTimeshiftStreamRequest(const std::string& serverAddress, const long dvbLinkChannelId, const std::string& clientId, TranscodingOptions& transcodingOptions);
+      H264TSTimeshiftStreamRequest(const std::string& serverAddress, const std::string& dvbLinkChannelId, const std::string& clientId, TranscodingOptions& transcodingOptions);
 
       /**
       * Destructor for cleaning up allocated memory.
@@ -529,7 +529,7 @@ namespace dvblinkremote {
     /**
       * Initializes a new instance of the dvblinkremote::HttpLiveStreamRequest class.
       * @param serverAddress a constant string reference representing the DVBLink server address.
-      * @param dvbLinkChannelId a constant long representing the DVBLink channel identifier.
+      * @param dvbLinkChannelId a constant string representing the DVBLink channel identifier.
       * @param clientId a constant string reference representing the unique identification string of the client. 
       * @param transcodingOptions a dvblinkremote::TranscodingOptions instance reference representing the transcoding options 
       * of the stream request. 
@@ -537,7 +537,7 @@ namespace dvblinkremote {
       * \remark \p clientId should be the same across all DVBLink Client API calls from a given client. 
       * It can be a uuid for example or id/mac of the client device.
       */
-    HttpLiveStreamRequest(const std::string& serverAddress, const long dvbLinkChannelId, const std::string& clientId, TranscodingOptions& transcodingOptions);
+    HttpLiveStreamRequest(const std::string& serverAddress, const std::string& dvbLinkChannelId, const std::string& clientId, TranscodingOptions& transcodingOptions);
 
     /**
       * Destructor for cleaning up allocated memory.
@@ -556,7 +556,7 @@ namespace dvblinkremote {
     /**
       * Initializes a new instance of the dvblinkremote::WindowsMediaStreamRequest class.
       * @param serverAddress a constant string reference representing the DVBLink server address.
-      * @param dvbLinkChannelId a constant long representing the DVBLink channel identifier.
+      * @param dvbLinkChannelId a constant string representing the DVBLink channel identifier.
       * @param clientId a constant string reference representing the unique identification string of the client. 
       * @param transcodingOptions a dvblinkremote::TranscodingOptions instance reference representing the transcoding options
       * of the stream request. 
@@ -564,7 +564,7 @@ namespace dvblinkremote {
       * \remark \p clientId should be the same across all DVBLink Client API calls from a given client. 
       * It can be a uuid for example or id/mac of the client device.
       */
-    WindowsMediaStreamRequest(const std::string& serverAddress, const long dvbLinkChannelId, const std::string& clientId, TranscodingOptions& transcodingOptions);
+    WindowsMediaStreamRequest(const std::string& serverAddress, const std::string& dvbLinkChannelId, const std::string& clientId, TranscodingOptions& transcodingOptions);
 
     /**
       * Destructor for cleaning up allocated memory.
@@ -583,13 +583,13 @@ namespace dvblinkremote {
     /**
       * Initializes a new instance of the dvblinkremote::RawHttpStreamRequest class.
       * @param serverAddress a constant string reference representing the DVBLink server address.
-      * @param dvbLinkChannelId a constant long representing the DVBLink channel identifier.
+      * @param dvbLinkChannelId a constant string representing the DVBLink channel identifier.
       * @param clientId a constant string reference representing the unique identification string of the client. 
       * \remark \p serverAddress is the IP address/server network name of the DVBLink server. 
       * \remark \p clientId should be the same across all DVBLink Client API calls from a given client. 
       * It can be a uuid for example or id/mac of the client device.
       */
-    RawHttpStreamRequest(const std::string& serverAddress, const long dvbLinkChannelId, const std::string& clientId);
+    RawHttpStreamRequest(const std::string& serverAddress, const std::string& dvbLinkChannelId, const std::string& clientId);
 
     /**
       * Destructor for cleaning up allocated memory.
@@ -608,13 +608,13 @@ namespace dvblinkremote {
     /**
       * Initializes a new instance of the dvblinkremote::RawHttpStreamRequest class.
       * @param serverAddress a constant string reference representing the DVBLink server address.
-      * @param dvbLinkChannelId a constant long representing the DVBLink channel identifier.
+      * @param dvbLinkChannelId a constant string representing the DVBLink channel identifier.
       * @param clientId a constant string reference representing the unique identification string of the client. 
       * \remark \p serverAddress is the IP address/server network name of the DVBLink server. 
       * \remark \p clientId should be the same across all DVBLink Client API calls from a given client. 
       * It can be a uuid for example or id/mac of the client device.
       */
-    RawHttpTimeshiftStreamRequest(const std::string& serverAddress, const long dvbLinkChannelId, const std::string& clientId);
+    RawHttpTimeshiftStreamRequest(const std::string& serverAddress, const std::string& dvbLinkChannelId, const std::string& clientId);
 
     /**
       * Destructor for cleaning up allocated memory.
@@ -633,7 +633,7 @@ namespace dvblinkremote {
     /**
       * Initializes a new instance of the dvblinkremote::RawUdpStreamRequest class.
       * @param serverAddress a constant string reference representing the DVBLink server address.
-      * @param dvbLinkChannelId a constant long representing the DVBLink channel identifier.
+      * @param dvbLinkChannelId a constant string representing the DVBLink channel identifier.
       * @param clientId a constant string reference representing the unique identification string of the client. 
       * @param clientAddress a constant string reference representing the client address.
       * @param streamingPort a constant unsigned short representing the streaming port.
@@ -641,7 +641,7 @@ namespace dvblinkremote {
       * \remark \p clientId should be the same across all DVBLink Client API calls from a given client. 
       * It can be a uuid for example or id/mac of the client device.
       */
-    RawUdpStreamRequest(const std::string& serverAddress, const long dvbLinkChannelId, const std::string& clientId, const std::string& clientAddress, const unsigned short int streamingPort);
+    RawUdpStreamRequest(const std::string& serverAddress, const std::string& dvbLinkChannelId, const std::string& clientId, const std::string& clientAddress, const unsigned short int streamingPort);
 
     /**
       * Destructor for cleaning up allocated memory.
@@ -1395,4 +1395,88 @@ namespace dvblinkremote {
         */
         ~GetServerInfoRequest();
     };
+
+    /**
+    * Class for timeshift stats request.
+    * This is used as input parameter for the IDVBLinkRemoteConnection::GetTimeshiftStats method.
+    * @see IDVBLinkRemoteConnection::GetTimeshiftStats()
+    */
+    class GetTimeshiftStatsRequest : public Request
+    {
+    public:
+      /**
+      * Initializes a new instance of the dvblinkremote::GetTimeshiftStatsRequest class.
+      * @param channelHandle a constant long representing the channel handle of an
+      * existing playing timeshifted stream.
+      * @see dvblinkremote::StreamRequest() for information about the channel handle.
+      */
+      GetTimeshiftStatsRequest(long channelHandle);
+
+      /**
+      * Destructor for cleaning up allocated memory.
+      */
+      ~GetTimeshiftStatsRequest();
+
+      /**
+      * Gets the channel handle.
+      * @return Channel handle
+      */
+      long GetChannelHandle();
+
+    private:
+      /**
+      * The channel handle to obtain the timeshift stats for.
+      */
+      long m_channelHandle;
+    };
+
+    /**
+    * Class for timeshift seek request.
+    * This is used as input parameter for the IDVBLinkRemoteConnection::TimeshiftSeek method.
+    * @see IDVBLinkRemoteConnection::TimeshiftSeek()
+    */
+    class TimeshiftSeekRequest : public Request
+    {
+    public:
+      /**
+      * Initializes a new instance of the dvblinkremote::TimeshiftSeekRequest class.
+      * @param channelHandle a constant long representing the channel handle of an
+      * existing playing timeshifted stream.
+      * @see dvblinkremote::StreamRequest() for information about the channel handle.
+      * @param byBytes type of seek operation: true - by bytes, false - by time
+      * @param offset offset in bytes (for seek by bytes) or in seconds (for seek by time). 
+      * Offset may be negative value and is calculated from a position, given by whence parameter.
+      * @param whence 0 - offset is calculated from the beginning of the timeshift buffer, 
+      * 1 - offset is calculated from the current playback position, 
+      * 2 - offset is calculated from the end of the timeshift buffer
+      */
+      TimeshiftSeekRequest(long channelHandle, bool byBytes, long long offset, long whence);
+
+      /**
+      * Destructor for cleaning up allocated memory.
+      */
+      ~TimeshiftSeekRequest();
+
+      /**
+      * The channel handle.
+      */
+      long m_channelHandle;
+
+      /**
+      * Seel type: 0 - by bytes, 1 - by time
+      */
+      long m_seekTypeSwitch;
+
+      /**
+      * Seek offset.
+      */
+      long long m_offset;
+
+      /**
+      * Seek origin.
+      */
+      long m_whence;
+
+    };
+
 }

--- a/lib/libdvblinkremote/response.h
+++ b/lib/libdvblinkremote/response.h
@@ -57,7 +57,7 @@ namespace dvblinkremote {
       * @param number an optional constant integer representing the number of the channel.
       * @param subNumber an optional constant integer representing the sub-number of the channel.
       */
-    Channel(const std::string& id, const long dvbLinkId, const std::string& name, const DVBLinkChannelType type, 
+    Channel(const std::string& id, const std::string& dvbLinkId, const std::string& name, const DVBLinkChannelType type, 
       const std::string& logo_url, const int number = -1, const int subNumber = -1);
 
     /**
@@ -82,7 +82,7 @@ namespace dvblinkremote {
       * Gets the DVBLink identifier of the channel. 
       * @return DVBLink channel identifier
       */
-    long GetDvbLinkID();
+    std::string& GetDvbLinkID();
     
     /**
       * Gets the name of the channel.
@@ -119,7 +119,7 @@ namespace dvblinkremote {
     
   private:
     std::string m_id;
-    long m_dvbLinkId;
+    std::string m_dvbLinkId;
     std::string m_name;
     DVBLinkChannelType m_type;
     std::string m_logo_url;
@@ -1305,6 +1305,10 @@ namespace dvblinkremote {
 
     bool IsTranscoderSupported(const DVBLinkSupportedTranscoder transcoder);
     bool IsTranscoderSupported(const int transcodersToCheck);
+
+    bool SupportsRecording;
+    bool SupportsTimeShifting;
+    bool SupportsDeviceManagement;
   };
 
   /**
@@ -1433,6 +1437,58 @@ namespace dvblinkremote {
       std::string server_id_;
       std::string version_;
       std::string build_;
+  };
+
+  /**
+  * Represent timeshift statistcs object, which is used as output parameter for the
+  * IDVBLinkRemoteConnection::GetTimeshiftStats method.
+  * @see IDVBLinkRemoteConnection::GetTimeshiftStats()
+  */
+  class TimeshiftStats : public Response
+  {
+  public:
+    /**
+    * TimeshiftStats a new instance of the dvblinkremote::TimeshiftStats class.
+    */
+    TimeshiftStats();
+
+    /**
+    * Initializes a new instance of the dvblinkremote::TimeshiftStats class by coping another
+    * dvblinkremote::TimeshiftStats instance.
+    * @param timeshiftStats a dvblinkremote::TimeshiftStats reference.
+    */
+    TimeshiftStats(TimeshiftStats& timeshiftStats);
+
+    /**
+    * Destructor for cleaning up allocated memory.
+    */
+    ~TimeshiftStats();
+
+    /**
+    * Maximum size of the timeshift buffer in bytes.
+    */
+    long long maxBufferLength;
+
+    /**
+    * current size of the timeshift buffer in bytes (may be less than max_buffer_length while buffer is growing)
+    */
+    long long curBufferLength;
+
+    /**
+    * current playback position within the timeshift buffer in bytes (range: between 0 and buffer_length)
+    */
+    long long curPosBytes;
+
+    /**
+    * duration of the timeshift buffer in seconds
+    */
+    long long bufferDurationSec;
+
+    /**
+    * current playback position within the timeshift buffer in seconds (range: between 0 and buffer_duration)
+    */
+    long long curPosSec;
+
   };
 
 }

--- a/lib/libdvblinkremote/stream_request.cpp
+++ b/lib/libdvblinkremote/stream_request.cpp
@@ -28,7 +28,7 @@
 using namespace dvblinkremote;
 using namespace dvblinkremoteserialization;
 
-StreamRequest::StreamRequest(const std::string& serverAddress, const long dvbLinkChannelId, const std::string& clientId, const std::string& streamType)
+StreamRequest::StreamRequest(const std::string& serverAddress, const std::string& dvbLinkChannelId, const std::string& clientId, const std::string& streamType)
   : m_serverAddress(serverAddress), 
     m_dvbLinkChannelId(dvbLinkChannelId), 
     m_clientId(clientId), 
@@ -47,7 +47,7 @@ std::string& StreamRequest::GetServerAddress()
   return m_serverAddress; 
 }
 
-long StreamRequest::GetDVBLinkChannelID() 
+std::string& StreamRequest::GetDVBLinkChannelID() 
 { 
   return m_dvbLinkChannelId; 
 }
@@ -62,7 +62,7 @@ std::string& StreamRequest::GetStreamType()
   return m_streamType; 
 }
 
-RawHttpStreamRequest::RawHttpStreamRequest(const std::string& serverAddress, const long channelDvbLinkId, const std::string& clientId)
+RawHttpStreamRequest::RawHttpStreamRequest(const std::string& serverAddress, const std::string& channelDvbLinkId, const std::string& clientId)
   : StreamRequest(serverAddress, channelDvbLinkId, clientId, DVBLINK_REMOTE_STREAM_TYPE_RAW_HTTP)
 {
 
@@ -73,7 +73,7 @@ RawHttpStreamRequest::~RawHttpStreamRequest()
 
 }
 
-RawHttpTimeshiftStreamRequest::RawHttpTimeshiftStreamRequest(const std::string& serverAddress, const long channelDvbLinkId, const std::string& clientId)
+RawHttpTimeshiftStreamRequest::RawHttpTimeshiftStreamRequest(const std::string& serverAddress, const std::string& channelDvbLinkId, const std::string& clientId)
   : StreamRequest(serverAddress, channelDvbLinkId, clientId, DVBLINK_REMOTE_STREAM_TYPE_RAW_HTTP_TIMESHIFT)
 {
 
@@ -84,7 +84,7 @@ RawHttpTimeshiftStreamRequest::~RawHttpTimeshiftStreamRequest()
 
 }
 
-RawUdpStreamRequest::RawUdpStreamRequest(const std::string& serverAddress, const long channelDvbLinkId, const std::string& clientId, const std::string& clientAddress, const unsigned short int streamingPort)
+RawUdpStreamRequest::RawUdpStreamRequest(const std::string& serverAddress, const std::string& channelDvbLinkId, const std::string& clientId, const std::string& clientAddress, const unsigned short int streamingPort)
   : m_clientAddress(clientAddress), m_streamingPort(streamingPort), StreamRequest(serverAddress, channelDvbLinkId, clientId, DVBLINK_REMOTE_STREAM_TYPE_RAW_UDP)
 { }
 
@@ -103,7 +103,7 @@ long RawUdpStreamRequest::GetStreamingPort()
   return m_streamingPort; 
 }
 
-MP4StreamRequest::MP4StreamRequest(const std::string& serverAddress, const long channelDvbLinkId, const std::string& clientId, TranscodingOptions& transcodingOptions)
+MP4StreamRequest::MP4StreamRequest(const std::string& serverAddress, const std::string& channelDvbLinkId, const std::string& clientId, TranscodingOptions& transcodingOptions)
 	: TranscodedVideoStreamRequest(serverAddress, channelDvbLinkId, clientId, transcodingOptions, DVBLINK_REMOTE_STREAM_TYPE_MP4)
 {
 
@@ -114,7 +114,7 @@ MP4StreamRequest::~MP4StreamRequest()
 
 }
 
-H264TSStreamRequest::H264TSStreamRequest(const std::string& serverAddress, const long channelDvbLinkId, const std::string& clientId, TranscodingOptions& transcodingOptions)
+H264TSStreamRequest::H264TSStreamRequest(const std::string& serverAddress, const std::string& channelDvbLinkId, const std::string& clientId, TranscodingOptions& transcodingOptions)
     : TranscodedVideoStreamRequest(serverAddress, channelDvbLinkId, clientId, transcodingOptions, DVBLINK_REMOTE_STREAM_TYPE_H264TS)
 {
 
@@ -125,7 +125,7 @@ H264TSStreamRequest::~H264TSStreamRequest()
 
 }
 
-H264TSTimeshiftStreamRequest::H264TSTimeshiftStreamRequest(const std::string& serverAddress, const long channelDvbLinkId, const std::string& clientId, TranscodingOptions& transcodingOptions)
+H264TSTimeshiftStreamRequest::H264TSTimeshiftStreamRequest(const std::string& serverAddress, const std::string& channelDvbLinkId, const std::string& clientId, TranscodingOptions& transcodingOptions)
     : TranscodedVideoStreamRequest(serverAddress, channelDvbLinkId, clientId, transcodingOptions, DVBLINK_REMOTE_STREAM_TYPE_H264TS_HTTP_TIMESHIFT)
 {
 
@@ -136,7 +136,7 @@ H264TSTimeshiftStreamRequest::~H264TSTimeshiftStreamRequest()
 
 }
 
-HttpLiveStreamRequest::HttpLiveStreamRequest(const std::string& serverAddress, const long channelDvbLinkId, const std::string& clientId, TranscodingOptions& transcodingOptions)
+HttpLiveStreamRequest::HttpLiveStreamRequest(const std::string& serverAddress, const std::string& channelDvbLinkId, const std::string& clientId, TranscodingOptions& transcodingOptions)
   : TranscodedVideoStreamRequest(serverAddress, channelDvbLinkId, clientId, transcodingOptions, DVBLINK_REMOTE_STREAM_TYPE_IPHONE)
 { 
 
@@ -147,7 +147,7 @@ HttpLiveStreamRequest::~HttpLiveStreamRequest()
 
 }
 
-RealTimeTransportProtocolStreamRequest::RealTimeTransportProtocolStreamRequest(const std::string& serverAddress, const long channelDvbLinkId, const std::string& clientId, TranscodingOptions& transcodingOptions)
+RealTimeTransportProtocolStreamRequest::RealTimeTransportProtocolStreamRequest(const std::string& serverAddress, const std::string& channelDvbLinkId, const std::string& clientId, TranscodingOptions& transcodingOptions)
   : TranscodedVideoStreamRequest(serverAddress, channelDvbLinkId, clientId, transcodingOptions, DVBLINK_REMOTE_STREAM_TYPE_ANDROID)
 { 
 
@@ -158,7 +158,7 @@ RealTimeTransportProtocolStreamRequest::~RealTimeTransportProtocolStreamRequest(
 
 }
 
-WindowsMediaStreamRequest::WindowsMediaStreamRequest(const std::string& serverAddress, const long channelDvbLinkId, const std::string& clientId, TranscodingOptions& transcodingOptions)
+WindowsMediaStreamRequest::WindowsMediaStreamRequest(const std::string& serverAddress, const std::string& channelDvbLinkId, const std::string& clientId, TranscodingOptions& transcodingOptions)
   : TranscodedVideoStreamRequest(serverAddress, channelDvbLinkId, clientId, transcodingOptions, DVBLINK_REMOTE_STREAM_TYPE_WINPHONE)
 { 
   

--- a/lib/libdvblinkremote/streaming_capabilities.cpp
+++ b/lib/libdvblinkremote/streaming_capabilities.cpp
@@ -36,13 +36,20 @@ GetStreamingCapabilitiesRequest::~GetStreamingCapabilitiesRequest()
 
 StreamingCapabilities::StreamingCapabilities() 
   : SupportedProtocols(0),
-    SupportedTranscoders(0)
+    SupportedTranscoders(0),
+    SupportsRecording(false),
+    SupportsTimeShifting(false),
+    SupportsDeviceManagement(false)
+
 { }
 
 StreamingCapabilities::StreamingCapabilities(StreamingCapabilities& streamingCapabilities)
 {
   SupportedProtocols = streamingCapabilities.SupportedProtocols;
   SupportedTranscoders = streamingCapabilities.SupportedTranscoders;
+  SupportsRecording = streamingCapabilities.SupportsRecording;
+  SupportsTimeShifting = streamingCapabilities.SupportsTimeShifting;
+  SupportsDeviceManagement = streamingCapabilities.SupportsDeviceManagement;
 }
 
 StreamingCapabilities::~StreamingCapabilities()
@@ -87,6 +94,9 @@ bool StreamingCapabilitiesSerializer::ReadObject(StreamingCapabilities& object, 
     tinyxml2::XMLElement* elRoot = doc.FirstChildElement("streaming_caps");
     object.SupportedProtocols = Util::GetXmlFirstChildElementTextAsInt(elRoot, "protocols");
     object.SupportedTranscoders = Util::GetXmlFirstChildElementTextAsInt(elRoot, "transcoders");
+    object.SupportsRecording = Util::GetXmlFirstChildElementTextAsBoolean(elRoot, "can_record");
+    object.SupportsTimeShifting = Util::GetXmlFirstChildElementTextAsBoolean(elRoot, "supports_timeshift");
+    object.SupportsDeviceManagement = Util::GetXmlFirstChildElementTextAsBoolean(elRoot, "device_management");
     return true;
   }
 

--- a/lib/libdvblinkremote/timeshift.cpp
+++ b/lib/libdvblinkremote/timeshift.cpp
@@ -1,0 +1,109 @@
+/***************************************************************************
+ * Copyright (C) 2012 Marcus Efraimsson.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a 
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included 
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ *
+ ***************************************************************************/
+
+#include "request.h"
+#include "response.h"
+#include "xml_object_serializer.h"
+
+using namespace dvblinkremote;
+using namespace dvblinkremoteserialization;
+
+GetTimeshiftStatsRequest::GetTimeshiftStatsRequest(long channelHandle) :
+  m_channelHandle(channelHandle)
+{ }
+
+GetTimeshiftStatsRequest::~GetTimeshiftStatsRequest()
+{ }
+
+long GetTimeshiftStatsRequest::GetChannelHandle()
+{
+  return m_channelHandle;
+}
+
+TimeshiftStats::TimeshiftStats() :
+  maxBufferLength(0), curBufferLength(0), curPosBytes(0), bufferDurationSec(0), curPosSec(0)
+{ }
+
+TimeshiftStats::TimeshiftStats(TimeshiftStats& timeshiftStats) :
+  maxBufferLength(timeshiftStats.maxBufferLength), curBufferLength(timeshiftStats.curBufferLength), curPosBytes(timeshiftStats.curPosBytes), 
+  bufferDurationSec(timeshiftStats.bufferDurationSec), curPosSec(timeshiftStats.curPosSec)
+{ }
+
+TimeshiftStats::~TimeshiftStats()
+{ }
+
+bool GetTimeshiftStatsRequestSerializer::WriteObject(std::string& serializedData, GetTimeshiftStatsRequest& objectGraph)
+{
+  tinyxml2::XMLElement* rootElement = PrepareXmlDocumentForObjectSerialization("timeshift_status"); 
+
+  rootElement->InsertEndChild(Util::CreateXmlElementWithText(&GetXmlDocument(), "channel_handle", objectGraph.GetChannelHandle()));
+
+  tinyxml2::XMLPrinter* printer = new tinyxml2::XMLPrinter();    
+  GetXmlDocument().Accept(printer);
+  serializedData = std::string(printer->CStr());
+  
+  return true;
+}
+
+bool TimeshiftStatsSerializer::ReadObject(TimeshiftStats& object, const std::string& xml)
+{
+  tinyxml2::XMLDocument& doc = GetXmlDocument();
+    
+  if (doc.Parse(xml.c_str()) == tinyxml2::XML_SUCCESS) {
+    tinyxml2::XMLElement* elRoot = doc.FirstChildElement("timeshift_status");
+    object.maxBufferLength = Util::GetXmlFirstChildElementTextAsLongLong(elRoot, "max_buffer_length");
+    object.curBufferLength = Util::GetXmlFirstChildElementTextAsLongLong(elRoot, "buffer_length");
+    object.curPosBytes = Util::GetXmlFirstChildElementTextAsLongLong(elRoot, "cur_pos_bytes");
+    object.bufferDurationSec = Util::GetXmlFirstChildElementTextAsLongLong(elRoot, "buffer_duration");
+    object.curPosSec = Util::GetXmlFirstChildElementTextAsLongLong(elRoot, "cur_pos_sec");
+    return true;
+  }
+
+  return false;
+}
+
+TimeshiftSeekRequest::TimeshiftSeekRequest(long channelHandle, bool byBytes, long long offset, long whence) :
+  m_channelHandle(channelHandle), m_offset(offset), m_whence(whence)
+{
+  m_seekTypeSwitch = byBytes ? 0 : 1;
+}
+
+TimeshiftSeekRequest::~TimeshiftSeekRequest()
+{ }
+
+bool TimeshiftSeekRequestSerializer::WriteObject(std::string& serializedData, TimeshiftSeekRequest& objectGraph)
+{
+  tinyxml2::XMLElement* rootElement = PrepareXmlDocumentForObjectSerialization("timeshift_seek");
+
+  rootElement->InsertEndChild(Util::CreateXmlElementWithText(&GetXmlDocument(), "channel_handle", objectGraph.m_channelHandle));
+  rootElement->InsertEndChild(Util::CreateXmlElementWithText(&GetXmlDocument(), "type", objectGraph.m_seekTypeSwitch));
+  rootElement->InsertEndChild(Util::CreateXmlElementWithText(&GetXmlDocument(), "offset", objectGraph.m_offset));
+  rootElement->InsertEndChild(Util::CreateXmlElementWithText(&GetXmlDocument(), "whence", objectGraph.m_whence));
+
+  tinyxml2::XMLPrinter* printer = new tinyxml2::XMLPrinter();
+  GetXmlDocument().Accept(printer);
+  serializedData = std::string(printer->CStr());
+
+  return true;
+}
+

--- a/lib/libdvblinkremote/transcoded_video_stream_request.cpp
+++ b/lib/libdvblinkremote/transcoded_video_stream_request.cpp
@@ -25,7 +25,7 @@
 
 using namespace dvblinkremote;
 
-TranscodedVideoStreamRequest::TranscodedVideoStreamRequest(const std::string& serverAddress, const long channelDvbLinkId, const std::string& clientId, TranscodingOptions& transcodingOptions, const std::string& streamType)
+TranscodedVideoStreamRequest::TranscodedVideoStreamRequest(const std::string& serverAddress, const std::string& channelDvbLinkId, const std::string& clientId, TranscodingOptions& transcodingOptions, const std::string& streamType)
   : m_transcodingOptions(transcodingOptions), StreamRequest(serverAddress, channelDvbLinkId, clientId, streamType)
 { 
 

--- a/lib/libdvblinkremote/util.cpp
+++ b/lib/libdvblinkremote/util.cpp
@@ -80,6 +80,11 @@ bool Util::ConvertToString(const long& value, std::string& s)
   return to_string(value, s);
 }
 
+bool Util::ConvertToString(const long long& value, std::string& s)
+{
+  return to_string(value, s);
+}
+
 bool Util::ConvertToString(const bool& value, std::string& s) 
 {
   if (value) {
@@ -140,6 +145,17 @@ tinyxml2::XMLElement* Util::CreateXmlElementWithText(tinyxml2::XMLDocument* xmlD
 }
 
 tinyxml2::XMLElement* Util::CreateXmlElementWithText(tinyxml2::XMLDocument* xmlDocument, const char* elementName, bool value) 
+{
+  std::string s;
+
+  if (Util::ConvertToString(value, s)) {
+    return CreateXmlElementWithText(xmlDocument, elementName, s.c_str());
+  }
+
+  return NULL;
+}
+
+tinyxml2::XMLElement* Util::CreateXmlElementWithText(tinyxml2::XMLDocument* xmlDocument, const char* elementName, long long value)
 {
   std::string s;
 

--- a/lib/libdvblinkremote/util.h
+++ b/lib/libdvblinkremote/util.h
@@ -38,6 +38,7 @@ namespace dvblinkremote {
     static bool ConvertToString(const int& value, std::string&);
     static bool ConvertToString(const unsigned int& value, std::string&);
     static bool ConvertToString(const long& value, std::string&);
+    static bool ConvertToString(const long long& value, std::string&);
     static bool ConvertToString(const bool& value, std::string&);
     static tinyxml2::XMLElement* CreateXmlElementWithText(tinyxml2::XMLDocument* xmlDocument, const char* elementName, const char* value);
     static tinyxml2::XMLElement* CreateXmlElementWithText(tinyxml2::XMLDocument* xmlDocument, const char* elementName, const std::string& value);
@@ -45,6 +46,7 @@ namespace dvblinkremote {
     static tinyxml2::XMLElement* CreateXmlElementWithText(tinyxml2::XMLDocument* xmlDocument, const char* elementName, unsigned int value);
     static tinyxml2::XMLElement* CreateXmlElementWithText(tinyxml2::XMLDocument* xmlDocument, const char* elementName, long value);
     static tinyxml2::XMLElement* CreateXmlElementWithText(tinyxml2::XMLDocument* xmlDocument, const char* elementName, bool value);
+    static tinyxml2::XMLElement* CreateXmlElementWithText(tinyxml2::XMLDocument* xmlDocument, const char* elementName, long long value);
     static const char* GetXmlFirstChildElementText(const tinyxml2::XMLElement* parentElement, const char* name);
     static int GetXmlFirstChildElementTextAsInt(const tinyxml2::XMLElement* parentElement, const char* name);
     static long GetXmlFirstChildElementTextAsLong(const tinyxml2::XMLElement* parentElement, const char* name);

--- a/lib/libdvblinkremote/xml_object_serializer.h
+++ b/lib/libdvblinkremote/xml_object_serializer.h
@@ -400,6 +400,27 @@ namespace dvblinkremoteserialization {
       bool ReadObject(ServerInfo& object, const std::string& xml);
   };
 
+  class GetTimeshiftStatsRequestSerializer : public XmlObjectSerializer<GetTimeshiftStatsRequest>
+  {
+  public:
+    GetTimeshiftStatsRequestSerializer() : XmlObjectSerializer<GetTimeshiftStatsRequest>() { }
+    bool WriteObject(std::string& serializedData, GetTimeshiftStatsRequest& objectGraph);
+  };
+
+  class TimeshiftStatsSerializer : public XmlObjectSerializer<TimeshiftStats>
+  {
+  public:
+    TimeshiftStatsSerializer() : XmlObjectSerializer<TimeshiftStats>() { }
+    bool ReadObject(TimeshiftStats& object, const std::string& xml);
+  };
+
+  class TimeshiftSeekRequestSerializer : public XmlObjectSerializer<TimeshiftSeekRequest>
+  {
+  public:
+    TimeshiftSeekRequestSerializer() : XmlObjectSerializer<TimeshiftSeekRequest>() { }
+    bool WriteObject(std::string& serializedData, TimeshiftSeekRequest& objectGraph);
+  };
+
   class ItemMetadataSerializer
   {
   public:

--- a/lib/libdvblinkremote/xml_object_serializer_factory.cpp
+++ b/lib/libdvblinkremote/xml_object_serializer_factory.cpp
@@ -114,6 +114,14 @@ bool XmlObjectSerializerFactory::Serialize(const std::string& dvbLinkCommand, co
       requestSerializer = (XmlObjectSerializer<Request>*)new GetFavoritesRequestSerializer();
       result = ((GetFavoritesRequestSerializer*)requestSerializer)->WriteObject(serializedData, (GetFavoritesRequest&)request);
   }
+  else if (dvbLinkCommand == DVBLINK_REMOTE_GET_TIMESHIFT_STATS_CMD) {
+    requestSerializer = (XmlObjectSerializer<Request>*)new GetTimeshiftStatsRequestSerializer();
+    result = ((GetTimeshiftStatsRequestSerializer*)requestSerializer)->WriteObject(serializedData, (GetTimeshiftStatsRequest&)request);
+  }
+  else if (dvbLinkCommand == DVBLINK_REMOTE_TIMESHIFT_SEEK_CMD) {
+    requestSerializer = (XmlObjectSerializer<Request>*)new TimeshiftSeekRequestSerializer();
+    result = ((TimeshiftSeekRequestSerializer*)requestSerializer)->WriteObject(serializedData, (TimeshiftSeekRequest&)request);
+  }
   else {
     result = false;
   }
@@ -175,6 +183,10 @@ bool XmlObjectSerializerFactory::Deserialize(const std::string& dvbLinkCommand, 
       responseSerializer = (XmlObjectSerializer<Response>*)new ServerInfoSerializer();
       result = ((ServerInfoSerializer*)responseSerializer)->ReadObject((ServerInfo&)response, serializedData);
   }
+  else if (dvbLinkCommand == DVBLINK_REMOTE_GET_TIMESHIFT_STATS_CMD) {
+    responseSerializer = (XmlObjectSerializer<Response>*)new TimeshiftStatsSerializer();
+    result = ((TimeshiftStatsSerializer*)responseSerializer)->ReadObject((TimeshiftStats&)response, serializedData);
+  }
   else if (dvbLinkCommand == DVBLINK_REMOTE_ADD_SCHEDULE_CMD ||
            dvbLinkCommand == DVBLINK_REMOTE_UPDATE_SCHEDULE_CMD ||
            dvbLinkCommand == DVBLINK_REMOTE_REMOVE_SCHEDULE_CMD ||
@@ -182,6 +194,7 @@ bool XmlObjectSerializerFactory::Deserialize(const std::string& dvbLinkCommand, 
            dvbLinkCommand == DVBLINK_REMOTE_STOP_CHANNEL_CMD ||
            dvbLinkCommand == DVBLINK_REMOTE_REMOVE_OBJECT_CMD ||
            dvbLinkCommand == DVBLINK_REMOTE_STOP_RECORDING_CMD ||
+           dvbLinkCommand == DVBLINK_REMOTE_TIMESHIFT_SEEK_CMD ||
            dvbLinkCommand == DVBLINK_REMOTE_SET_RECORDING_SETTING_CMD) {
     result = true;
   }

--- a/pvr.dvblink/changelog.txt
+++ b/pvr.dvblink/changelog.txt
@@ -1,3 +1,14 @@
+[B]Version 3.4.0[/B]
+Fixed: Crash when switching channels with timeshift enabled ( #69 )
+Fixed: Hangup after period of inactivity ( #64 )
+Fixed: Incorrect dvblink server version displayed in addon proeprties ( #66 )
+Fixed: Timer Rules incorrectly detected ( #68 )
+Changed: default value to "new only" when setting series recording ( #65 )
+Added: timeshift commands to libdvblnikremote
+Changed: dvblink channel id to string for compatibility with future dvblink versions
+Added: margin of 10 seconds to IsRealTimeStream and IsTimeshifting definitions
+General: code refactoring for easier maintenance
+
 [B]Version 3.3.6[/B]
 Fixed: PVR_TIMER.iClientIndex handling bug
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -467,15 +467,15 @@ const char* GetMininumGUIAPIVersion(void)
 
 PVR_ERROR GetAddonCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities)
 {
-  pCapabilities->bSupportsEPG = true;
-  pCapabilities->bSupportsRecordings = true;
-  pCapabilities->bSupportsRecordingsUndelete = false;
-  pCapabilities->bSupportsTimers = true;
-  pCapabilities->bSupportsTV = true;
-  pCapabilities->bSupportsRadio = true;
-  pCapabilities->bHandlesInputStream = true;
-  pCapabilities->bSupportsChannelGroups = true;
-  return PVR_ERROR_NO_ERROR;
+  if (dvblinkclient)
+  {
+    if (dvblinkclient->GetStatus())
+    {
+      dvblinkclient->GetAddonCapabilities(pCapabilities);
+      return PVR_ERROR_NO_ERROR;
+    }
+  }
+  return PVR_ERROR_SERVER_ERROR;
 }
 
 const char *GetBackendName(void)
@@ -486,8 +486,14 @@ const char *GetBackendName(void)
 
 const char *GetBackendVersion(void)
 {
-  static const char * strBackendVersion = "5.x";
-  return strBackendVersion;
+  if (dvblinkclient)
+  {
+    if (dvblinkclient->GetStatus())
+    {
+      return dvblinkclient->GetBackendVersion();
+    }
+  }
+  return "";
 }
 
 const char *GetConnectionString(void)
@@ -568,7 +574,7 @@ bool OpenLiveStream(const PVR_CHANNEL &channel)
 void CloseLiveStream(void)
 {
   if (dvblinkclient)
-    dvblinkclient->StopStreaming(true);
+    dvblinkclient->StopStreaming();
 }
 
 const char * GetLiveStreamURL(const PVR_CHANNEL &channel)
@@ -644,7 +650,7 @@ static bool dvblink_is_live()
 {
   if (dvblinkclient)
   {
-    return (dvblinkclient->GetBufferTimeEnd() - dvblinkclient->GetPlayingTime()) < 3; //add a margin of 3 seconds to the definition of "live"
+    return (dvblinkclient->GetBufferTimeEnd() - dvblinkclient->GetPlayingTime()) < 10; //add a margin of 10 seconds to the definition of "live"
   }
   return true;
 }

--- a/src/dvblink_connection.h
+++ b/src/dvblink_connection.h
@@ -1,0 +1,86 @@
+/*
+ *      Copyright (C) 2005-2012 Team XBMC
+ *      http://xbmc.org
+ 
+ *      Copyright (C) 2012 Palle Ehmsen(Barcode Madness)
+ *      http://www.barcodemadness.com
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1301  USA
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#pragma once
+
+#include "p8-platform/os.h"
+#include "p8-platform/threads/threads.h"
+#include "p8-platform/threads/mutex.h"
+#include "p8-platform/util/util.h"
+#include "libdvblinkremote/dvblinkremote.h"
+#include "HttpPostClient.h"
+#include "xbmc_pvr_types.h"
+#include "libXBMC_addon.h"
+#include "libXBMC_pvr.h"
+#include "libKODI_guilib.h"
+
+struct server_connection_properties
+{
+  server_connection_properties(const std::string& address, long port, const std::string& username, const std::string& password, const std::string& client_id) :
+    address_(address), port_(port), username_(username), password_(password), client_id_(client_id)
+  {}
+
+  std::string address_;
+  long port_;
+  std::string username_;
+  std::string password_;
+  std::string client_id_;
+};
+
+class dvblink_server_connection : public dvblinkremote::DVBLinkRemoteLocker
+{
+  public:
+    dvblink_server_connection(ADDON::CHelper_libXBMC_addon* xbmc, const server_connection_properties& connection_props)
+    {
+      http_client_ = new HttpPostClient(xbmc, connection_props.address_, connection_props.port_, connection_props.username_, connection_props.password_);
+
+      dvblink_connection_ = dvblinkremote::DVBLinkRemote::Connect(*http_client_, connection_props.address_.c_str(), connection_props.port_,
+        connection_props.username_.c_str(), connection_props.password_.c_str(), this);
+    }
+
+    ~dvblink_server_connection()
+    {
+      SAFE_DELETE(dvblink_connection_);
+      SAFE_DELETE(http_client_);
+    }
+
+    dvblinkremote::IDVBLinkRemoteConnection* get_connection() { return dvblink_connection_ ;}
+
+protected:
+  virtual void lock()
+    {
+      m_comm_mutex.Lock();
+    }
+
+    virtual void unlock()
+    {
+      m_comm_mutex.Unlock();
+    }
+
+    P8PLATFORM::CMutex m_comm_mutex;
+    HttpPostClient* http_client_;
+    dvblinkremote::IDVBLinkRemoteConnection* dvblink_connection_;
+};
+


### PR DESCRIPTION
Fixed: Crash when switching channels with timeshift enabled ( #69 )
Fixed: Hangup after period of inactivity ( #64 )
Fixed: Incorrect dvblink server version displayed in addon properties ( #66 )
Fixed: Timer Rules incorrectly detected ( #68 )
Changed: default value to "new only" when setting series recording ( #65 )
Added: timeshift commands to libdvblnikremote
Changed: dvblink channel id to string for compatibility with future dvblink versions
Added: margin of 10 seconds to IsRealTimeStream and IsTimeshifting definitions
General: code refactoring for easier maintenance