### PR TITLE
pvr.dvblink (master) version 4.1.2

### DIFF
--- a/pvr.dvblink/addon.xml.in
+++ b/pvr.dvblink/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.dvblink"
-  version="4.1.1"
+  version="4.1.2"
   name="DVBLink PVR Client"
   provider-name="DVBLogic">
   <requires>

--- a/pvr.dvblink/changelog.txt
+++ b/pvr.dvblink/changelog.txt
@@ -1,3 +1,6 @@
+[B]Version 4.1.2[/B]
+Fixed: Incorrectly displayed days of week when editing manual repeating timer ( leftover of #68 )
+
 [B]Version 4.1.1[/B]
 Fixed: Timer Rules incorrectly detected for manual/keyword based timers ( #68 )
 

--- a/src/DVBLinkClient.cpp
+++ b/src/DVBLinkClient.cpp
@@ -643,6 +643,13 @@ int DVBLinkClient::GetSchedules(ADDON_HANDLE handle, const RecordingList& record
       timer.startTime = manual_schedules[i]->GetStartTime();
       timer.endTime = manual_schedules[i]->GetStartTime() + manual_schedules[i]->GetDuration();
 
+      //change day mask from DVBLink server (Sun - first day) to Kodi format 
+      long day_mask = manual_schedules[i]->GetDayMask();
+      bool bcarry = (day_mask & 0x01) == 0x01;
+      timer.iWeekdays = (day_mask >> 1);
+      if (bcarry)
+        timer.iWeekdays |= 0x40;
+
       PVR->TransferTimerEntry(handle, &timer);
       XBMC->Log(LOG_INFO, "Added EPG schedule : %s", manual_schedules[i]->GetID().c_str());
 


### PR DESCRIPTION
Fixed: Incorrectly displayed days of week when editing manual repeating timer ( leftover of #68 )