### PR TITLE
libXBMC_codec.h removed and changed to libXBMC_pvr.h

### DIFF
--- a/pvr.dvblink/addon.xml.in
+++ b/pvr.dvblink/addon.xml.in
@@ -6,7 +6,7 @@
   provider-name="DVBLogic">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="5.2.1"/>
+    <import addon="xbmc.pvr" version="5.2.2"/>
     <import addon="kodi.guilib" version="5.10.0"/>
   </requires>
   <extension


### PR DESCRIPTION
Related to Kodi Pull Request xbmc/xbmc#12028 where libXBMC_codec.h becomes removed.