### PR TITLE
pvr.dvblink v4.5.1

### DIFF
--- a/pvr.dvblink/addon.xml.in
+++ b/pvr.dvblink/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.dvblink"
-  version="4.5.0"
+  version="4.5.1"
   name="TVMosaic/DVBLink PVR Client"
   provider-name="DVBLogic">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.dvblink/changelog.txt
+++ b/pvr.dvblink/changelog.txt
@@ -1,3 +1,6 @@
+[B]Version 4.5.1[/B]
+Fixed: Reporting incorrect stream stats on 32 bits system
+
 [B]Version 4.5.0[/B]
 Updated to PVR API v5.8.0
 Added official TVMosaic compatibility

--- a/src/RecordingStreamer.cpp
+++ b/src/RecordingStreamer.cpp
@@ -112,7 +112,7 @@ PVR_ERROR RecordingStreamer::GetStreamTimes(PVR_STREAM_TIMES* stream_times)
     stream_times->startTime = 0;
     stream_times->ptsStart = 0;
     stream_times->ptsBegin = 0;
-    stream_times->ptsEnd = recording_duration_ * DVD_TIME_BASE;
+    stream_times->ptsEnd = (int64_t)recording_duration_ * DVD_TIME_BASE;
     return PVR_ERROR_NO_ERROR;
   }
 

--- a/src/TimeShiftBuffer.cpp
+++ b/src/TimeShiftBuffer.cpp
@@ -268,8 +268,8 @@ void TimeShiftBuffer::GetStreamTimes(PVR_STREAM_TIMES* stream_times)
   stream_times->ptsStart = 0;
   if (now >= buffer_params.buffer_duration + stream_start_ && now >= stream_start_)
   {
-    stream_times->ptsBegin = (now - buffer_params.buffer_duration - stream_start_) * DVD_TIME_BASE;
-    stream_times->ptsEnd = (now - stream_start_) * DVD_TIME_BASE;
+    stream_times->ptsBegin = (int64_t)(now - buffer_params.buffer_duration - stream_start_) * DVD_TIME_BASE;
+    stream_times->ptsEnd = (int64_t)(now - stream_start_) * DVD_TIME_BASE;
   } else
   {
     stream_times->ptsBegin = 0;


### PR DESCRIPTION
fixed: Reporting incorrect stream stats on 32 bits system