### PR TITLE
Reschedule 'Update Process' to update record now status

### DIFF
--- a/src/DVBLinkClient.h
+++ b/src/DVBLinkClient.h
@@ -199,6 +199,9 @@ private:
   bool m_group_recordings_by_series;
   bool m_showinfomsg;
   bool m_updating;
+  bool m_update_timers_now;
+  bool m_update_timers_repeat;
+  bool m_update_recordings;
   std::string m_recordingsid;
   std::string m_recordingsid_by_date;
   std::string m_recordingsid_by_series;


### PR DESCRIPTION
This reschedules the 'Update Process' so that after selecting a currently active program to record the record status is updated within a reasonable period of time. 

The issue is documented here: https://dvblogic.freshdesk.com/support/tickets/55630

This is achieved by splitting the timer and recording updaters within the 'Update Process' so that each can be called separately. Then moving all of the remaining timer and recording updaters into the 'Update Process'. This then allows a repeat call to be made to the timer updater when adding a timer so that the recording status gets updated on the second call about 5 seconds later.


This also enables a problem with Kodi crashing when deleting a folder containing multiple recordings to be fixed. See here - Kodi crashes when deleting multiple TV Recordings https://github.com/xbmc/xbmc/issues/15261

This problem is the result of calling PVR->TriggerRecordingUpdate() multiple times in succession. By offloading the call to PVR->TriggerRecordingUpdate() to the UpdateProcess thread it only gets called once after all of the recordings have been deleted. After each recording deletion the UpdateProcess timer is set forward from the current time effectively by two seconds so that the PVR->TriggerRecordingUpdate() will only be called once, two seconds after the last deletion.

This also provides the opportunity to fix this issue https://trac.kodi.tv/ticket/18043 by adding a call from DVBLinkClient::SetRecordingLastPlayedPosition to the recording updater within the 'Update Process' which then updates the recording status icon after resetting the resume position.