### PR TITLE
Fixed: deleted timers do not remain in the list as disabled (#118); R…

### DIFF
--- a/pvr.dvblink/changelog.txt
+++ b/pvr.dvblink/changelog.txt
@@ -1,6 +1,8 @@
 [B]Version 4.7.2[/B]
 Added: PVR_RECORDING.iChannelUid and PVR_RECORDING.channelType support
 Added: Setting to change the addon update interval
+Fixed: deleted timers do not remain in the list as disabled
+Removed: start any time flag for EPG recurring timers when working with TVMosaic server due to behavior inconsistency
 
 [B]Version 4.7.1[/B]
 Added: Option to change default 'Prevent duplicate episodes' setting

--- a/src/DVBLinkClient.h
+++ b/src/DVBLinkClient.h
@@ -123,7 +123,8 @@ struct dvblink_server_caps
     timeshifting_supported_(false),
     device_management_supported_(false),
     timeshift_commands_supported_(false),
-    resume_supported_(false)
+    resume_supported_(false),
+    start_any_time_supported_(false)
   {}
 
   std::string server_version_;
@@ -137,6 +138,7 @@ struct dvblink_server_caps
   bool device_management_supported_;
   bool timeshift_commands_supported_;
   bool resume_supported_;
+  bool start_any_time_supported_;
 };
 
 class DVBLinkClient: public P8PLATFORM::CThread


### PR DESCRIPTION
…emoved: start any time flag for EPG recurring timers when working with TVMosaic server due to behavior inconsistency (#113)