### PR TITLE
[cmake] remove usage of kodi-platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,12 +7,10 @@ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR})
 enable_language(CXX)
 
 find_package(Kodi REQUIRED)
-find_package(kodiplatform REQUIRED)
 find_package(p8-platform REQUIRED)
 find_package(TinyXML2 REQUIRED)
 
-include_directories(${kodiplatform_INCLUDE_DIRS}
-                    ${p8-platform_INCLUDE_DIRS}
+include_directories(${p8-platform_INCLUDE_DIRS}
                     ${KODI_INCLUDE_DIR}
                     ${TINYXML2_INCLUDE_DIRS}
                     ${PROJECT_SOURCE_DIR}/lib)

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: kodi-pvr-dvblink
 Priority: extra
 Maintainer: Nobody <nobody@kodi.tv>
 Build-Depends: debhelper (>= 9.0.0), cmake, libtinyxml2-dev,
-               libkodiplatform-dev (>= 16.0.0), kodi-addon-dev
+               libp8-platform-dev, kodi-addon-dev
 Standards-Version: 3.9.4
 Section: libs
 


### PR DESCRIPTION
The pvr.dvblink binary addon does not use kodi-platform.
Remove existing references from CMakeLists.txt and debian/control.