### PR TITLE
PVR API 6.2.0 Compatibility

### DIFF
--- a/pvr.dvblink/addon.xml.in
+++ b/pvr.dvblink/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.dvblink"
-  version="5.2.2"
+  version="5.3.0"
   name="TVMosaic/DVBLink PVR Client"
   provider-name="DVBLogic">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.dvblink/changelog.txt
+++ b/pvr.dvblink/changelog.txt
@@ -1,3 +1,6 @@
+[B]Version 5.3.0[/B]
+Update to PVR addon API v6.2.0
+
 [B]Version 5.2.0[/B]
 Recompile for 6.1.0 PVR Addon API compatibility
 

--- a/src/DVBLinkClient.cpp
+++ b/src/DVBLinkClient.cpp
@@ -1805,7 +1805,7 @@ PVR_ERROR DVBLinkClient::GetEPGForChannel(ADDON_HANDLE handle, int iChannelUid, 
         broadcast.iGenreType = 0;
         broadcast.iGenreSubType = 0;
         broadcast.strGenreDescription = "";
-        broadcast.firstAired = 0;
+        broadcast.strFirstAired = "";
         broadcast.iParentalRating = 0;
         broadcast.iStarRating = p->Rating;
         broadcast.iSeriesNumber = p->SeasonNumber;


### PR DESCRIPTION
This PR updates the pvr.dvblink PVR addon for compatibility with the proposed PVR API v6.2.0 [Kodi PR 17182](https://github.com/xbmc/xbmc/pull/17192).

This addon only requires a trivial conversion of the EPG_TAG.firstAired field to adapt to it becoming a const char*.