### PR TITLE
add p8-platform to addon itself as depends

### DIFF
--- a/depends/common/p8-platform/p8-platform.txt
+++ b/depends/common/p8-platform/p8-platform.txt
@@ -1,0 +1,1 @@
+p8-platform https://github.com/xbmc/platform.git cee64e9dc0b69e8d286dc170a78effaabfa09c44

--- a/depends/windowsstore/p8-platform/p8-platform.txt
+++ b/depends/windowsstore/p8-platform/p8-platform.txt
@@ -1,0 +1,1 @@
+p8-platform https://github.com/afedchin/platform.git win10


### PR DESCRIPTION
This is intended to significantly speed up the construction times for those who do not use these dependencies (most addons without this).

This will also happen to all other PVRs that need it and also allows you to add your own versions if necessary.

After converting this will be removed from Kodi.
Only used on the Matrix branches, the others remain with Kodi.