### PR TITLE
[Matrix] API change updates

### DIFF
--- a/pvr.dvblink/addon.xml.in
+++ b/pvr.dvblink/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.dvblink"
-  version="5.2.8"
+  version="5.2.9"
   name="TVMosaic/DVBLink PVR Client"
   provider-name="DVBLogic">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.dvblink/changelog.txt
+++ b/pvr.dvblink/changelog.txt
@@ -1,3 +1,6 @@
+[B]Version 5.2.9[/B]
+Update: PVR API 6.5.0
+
 [B]Version 5.2.8[/B]
 Update: PVR API 6.4.0
 Update: Add license name, forum url and source url to addon.xml

--- a/src/DVBLinkClient.cpp
+++ b/src/DVBLinkClient.cpp
@@ -229,7 +229,7 @@ const char* DVBLinkClient::GetBackendVersion()
   return server_caps_.server_version_.c_str();
 }
 
-void DVBLinkClient::GetAddonCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities)
+void DVBLinkClient::GetCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities)
 {
   pCapabilities->bSupportsEPG = true;
   pCapabilities->bSupportsRecordings = server_caps_.recordings_supported_;

--- a/src/DVBLinkClient.h
+++ b/src/DVBLinkClient.h
@@ -132,7 +132,7 @@ public:
       std::string password, bool add_episode_to_rec_title, bool group_recordings_by_series, bool no_group_single_rec, int default_update_interval, int default_rec_show_type);
   ~DVBLinkClient(void);
   const char *GetBackendVersion();
-  void GetAddonCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities);
+  void GetCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities);
   int GetChannelsAmount();
   PVR_ERROR GetChannels(ADDON_HANDLE handle, bool bRadio);
   PVR_ERROR GetEPGForChannel(ADDON_HANDLE handle, int iChannelUid, time_t iStart, time_t iEnd);

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -433,13 +433,13 @@ void OnPowerSavingDeactivated()
 {
 }
 
-PVR_ERROR GetAddonCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities)
+PVR_ERROR GetCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities)
 {
   if (dvblinkclient)
   {
     if (dvblinkclient->GetStatus())
     {
-      dvblinkclient->GetAddonCapabilities(pCapabilities);
+      dvblinkclient->GetCapabilities(pCapabilities);
       return PVR_ERROR_NO_ERROR;
     }
   }

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -683,7 +683,7 @@ PVR_ERROR GetRecordingEdl(const PVR_RECORDING&, PVR_EDL_ENTRY[], int*)
   return PVR_ERROR_NOT_IMPLEMENTED;
 }
 
-PVR_ERROR SignalStatus(PVR_SIGNAL_STATUS &signalStatus)
+PVR_ERROR GetSignalStatus(int channelUid, PVR_SIGNAL_STATUS *signalStatus)
 {
   return PVR_ERROR_NO_ERROR;
 }
@@ -894,7 +894,7 @@ void SetSpeed(int)
 {
 }
 
-PVR_ERROR GetDescrambleInfo(PVR_DESCRAMBLE_INFO* descrambleInfo)
+PVR_ERROR GetDescrambleInfo(int channelUid, PVR_DESCRAMBLE_INFO* descrambleInfo)
 {
   return PVR_ERROR_NOT_IMPLEMENTED;
 }

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -85,7 +85,7 @@ ADDON_STATUS ADDON_Create(void* hdl, void* props)
   if (!hdl || !props)
     return ADDON_STATUS_UNKNOWN;
 
-  PVR_PROPERTIES* pvrprops = (PVR_PROPERTIES*) props;
+  AddonProperties_PVR* pvrprops = (AddonProperties_PVR*) props;
 
   XBMC = new CHelper_libXBMC_addon;
   if (!XBMC->RegisterMe(hdl))


### PR DESCRIPTION
Related to xbmc/xbmc#17775 and to bring in after them.

Runtime test was partly OK. But a major bug was that playback not was possible (not related to changes here).
His message:
```
ERROR <general>: AddOnLog: TVMosaic/DVBLink PVR Client: Could not start streaming for channel 2:330000:1:1051:28721 (Error code : 1001)
```

As note, this request here and on other addons are mainly about API update, but try to test every addon to see it still works or need fixes in future.