### PR TITLE
Remove p8platform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ env:
 matrix:
   include:
     - os: linux
-      dist: xenial
+      dist: bionic
       sudo: required
       compiler: gcc
     - os: linux
-      dist: xenial
+      dist: bionic
       sudo: required
       compiler: clang
     - os: linux

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,11 +4,9 @@ project(pvr.dvblink)
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR})
 
 find_package(Kodi REQUIRED)
-find_package(p8-platform REQUIRED)
 find_package(TinyXML2 REQUIRED)
 
-include_directories(${p8-platform_INCLUDE_DIRS}
-                    ${KODI_INCLUDE_DIR}/.. # Hack way with "/..", need bigger Kodi cmake rework to match right include ways
+include_directories(${KODI_INCLUDE_DIR}/.. # Hack way with "/..", need bigger Kodi cmake rework to match right include ways
                     ${TINYXML2_INCLUDE_DIRS}
                     ${PROJECT_SOURCE_DIR}/lib)
 
@@ -34,7 +32,7 @@ set(DVBLINK_HEADERS src/addon.h
                     src/TimeShiftBuffer.h)
 
 add_subdirectory(lib/libdvblinkremote)
-set(DEPLIBS ${p8-platform_LIBRARIES} dvblinkremote ${TINYXML2_LIBRARIES})
+set(DEPLIBS dvblinkremote ${TINYXML2_LIBRARIES})
 if(WIN32)
   list(APPEND DEPLIBS ws2_32)
   add_definitions(-D_WINSOCKAPI_ -D_WINSOCK_DEPRECATED_NO_WARNINGS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ set(DVBLINK_SOURCES src/addon.cpp
                     src/base64.cpp
                     src/HttpPostClient.cpp
                     src/Settings.cpp
+                    src/Socket.cpp
                     src/DVBLinkClient.cpp
                     src/RecordingStreamer.cpp
                     src/TimeShiftBuffer.cpp)
@@ -27,12 +28,18 @@ set(DVBLINK_HEADERS src/addon.h
                     src/dvblink_connection.h
                     src/HttpPostClient.h
                     src/Settings.h
+                    src/Socket.h
                     src/DVBLinkClient.h
                     src/RecordingStreamer.h
                     src/TimeShiftBuffer.h)
 
 add_subdirectory(lib/libdvblinkremote)
 set(DEPLIBS ${p8-platform_LIBRARIES} dvblinkremote ${TINYXML2_LIBRARIES})
+if(WIN32)
+  list(APPEND DEPLIBS ws2_32)
+  add_definitions(-D_WINSOCKAPI_ -D_WINSOCK_DEPRECATED_NO_WARNINGS)
+endif()
+
 build_addon(pvr.dvblink DVBLINK DEPLIBS)
 
 include(CPack)

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: kodi-pvr-dvblink
 Priority: extra
 Maintainer: Nobody <nobody@kodi.tv>
 Build-Depends: debhelper (>= 9.0.0), cmake, libtinyxml2-dev,
-               libp8-platform-dev, kodi-addon-dev
+               kodi-addon-dev
 Standards-Version: 4.1.2
 Section: libs
 

--- a/depends/common/p8-platform/p8-platform.txt
+++ b/depends/common/p8-platform/p8-platform.txt
@@ -1,1 +1,0 @@
-p8-platform https://github.com/xbmc/platform.git cee64e9dc0b69e8d286dc170a78effaabfa09c44

--- a/depends/windowsstore/p8-platform/p8-platform.txt
+++ b/depends/windowsstore/p8-platform/p8-platform.txt
@@ -1,1 +1,0 @@
-p8-platform https://github.com/afedchin/platform.git win10

--- a/pvr.dvblink/addon.xml.in
+++ b/pvr.dvblink/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.dvblink"
-  version="9.0.0"
+  version="9.0.1"
   name="TVMosaic/DVBLink PVR Client"
   provider-name="DVBLogic">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.dvblink/changelog.txt
+++ b/pvr.dvblink/changelog.txt
@@ -1,3 +1,13 @@
+[B]Version 9.0.1[/B]
+Update: Remove p8-platform dependency
+Update: Use different socket implementation
+Update: Use std::thread
+Update: Use std::mutex
+Update: Remove p8 os header
+Update: Remove use of SAFE_DELETE and p8 util header
+Fixed: Fix proper return value if connected
+Update: Update inputstream API 3.0.1 - Fix wrong flags bit shift
+
 [B]Version 9.0.0[/B]
 Update: PVR API 7.0.2
 Fixed: Some compile warnings about missing ATTRIBUTE_HIDDEN

--- a/src/DVBLinkClient.cpp
+++ b/src/DVBLinkClient.cpp
@@ -13,7 +13,6 @@
 #include <kodi/General.h>
 #include <kodi/gui/General.h>
 #include <memory>
-#include <p8-platform/os.h>
 
 using namespace dvblinkremote;
 using namespace dvblinkremotehttp;

--- a/src/DVBLinkClient.cpp
+++ b/src/DVBLinkClient.cpp
@@ -1215,7 +1215,7 @@ PVR_ERROR DVBLinkClient::AddTimer(const kodi::addon::PVRTimer& timer)
       kodi::Log(ADDON_LOG_ERROR, "Could not add timer (Error code : %d Description : %s)",
                 (int)status, error.c_str());
     }
-    SAFE_DELETE(addScheduleRequest);
+    SafeDelete(addScheduleRequest);
   }
   else
   {
@@ -1700,7 +1700,7 @@ bool DVBLinkClient::OpenLiveStream(const kodi::addon::PVRChannel& channel)
   P8PLATFORM::CLockObject critsec(live_mutex_);
 
   if (m_live_streamer)
-    SAFE_DELETE(m_live_streamer);
+    SafeDelete(m_live_streamer);
 
   if (use_timeshift)
     m_live_streamer =
@@ -1781,7 +1781,7 @@ void DVBLinkClient::CloseLiveStream()
   if (m_live_streamer != nullptr)
   {
     m_live_streamer->Stop();
-    SAFE_DELETE(m_live_streamer);
+    SafeDelete(m_live_streamer);
     m_live_streamer = nullptr;
   }
 }
@@ -1959,7 +1959,7 @@ DVBLinkClient::~DVBLinkClient(void)
   if (m_live_streamer)
   {
     m_live_streamer->Stop();
-    SAFE_DELETE(m_live_streamer);
+    SafeDelete(m_live_streamer);
   }
 
   dvblink_channel_map_t::iterator ch_it = m_channels.begin();

--- a/src/DVBLinkClient.cpp
+++ b/src/DVBLinkClient.cpp
@@ -714,7 +714,7 @@ bool DVBLinkClient::parse_timer_hash(const char* timer_hash,
 
 unsigned int DVBLinkClient::get_kodi_timer_idx_from_dvblink(const std::string& id)
 {
-  P8PLATFORM::CLockObject critsec(m_mutex);
+  std::lock_guard<std::mutex> critsec(m_mutex);
 
   if (timer_idx_map_.find(id) == timer_idx_map_.end())
     timer_idx_map_[id] = timer_idx_seed_++;
@@ -724,14 +724,14 @@ unsigned int DVBLinkClient::get_kodi_timer_idx_from_dvblink(const std::string& i
 
 void DVBLinkClient::add_schedule_desc(const std::string& id, const schedule_desc& sd)
 {
-  P8PLATFORM::CLockObject critsec(m_mutex);
+  std::lock_guard<std::mutex> critsec(m_mutex);
 
   schedule_map_[id] = sd;
 }
 
 bool DVBLinkClient::get_schedule_desc(const std::string& id, schedule_desc& sd)
 {
-  P8PLATFORM::CLockObject critsec(m_mutex);
+  std::lock_guard<std::mutex> critsec(m_mutex);
 
   if (schedule_map_.find(id) != schedule_map_.end())
   {
@@ -760,7 +760,7 @@ int DVBLinkClient::GetSchedules(kodi::addon::PVRTimersResultSet& results,
   int total_count = 0;
 
   {
-    P8PLATFORM::CLockObject critsec(m_mutex);
+    std::lock_guard<std::mutex> critsec(m_mutex);
 
     schedule_map_.clear();
   }
@@ -1470,7 +1470,7 @@ PVR_ERROR DVBLinkClient::GetRecordings(bool deleted, kodi::addon::PVRRecordingsR
   DVBLinkRemoteStatusCode status;
 
   {
-    P8PLATFORM::CLockObject critsec(m_mutex);
+    std::lock_guard<std::mutex> critsec(m_mutex);
 
     m_recording_id_to_url_map.clear();
   }
@@ -1557,7 +1557,7 @@ PVR_ERROR DVBLinkClient::GetRecordings(bool deleted, kodi::addon::PVRRecordingsR
     xbmcRecording.SetPlot(tvitem->GetMetadata().ShortDescription);
     xbmcRecording.SetPlotOutline(tvitem->GetMetadata().SubTitle);
     {
-      P8PLATFORM::CLockObject critsec(m_mutex);
+      std::lock_guard<std::mutex> critsec(m_mutex);
 
       m_recording_id_to_url_map[xbmcRecording.GetRecordingId()] = tvitem->GetPlaybackUrl();
     }
@@ -1633,7 +1633,7 @@ bool DVBLinkClient::GetRecordingURL(const std::string& recording_id,
   }
 
   {
-    P8PLATFORM::CLockObject critsec(m_mutex);
+    std::lock_guard<std::mutex>critsec(m_mutex);
     if (m_recording_id_to_url_map.find(recording_id) == m_recording_id_to_url_map.end())
       return false;
 
@@ -1696,7 +1696,7 @@ bool DVBLinkClient::OpenLiveStream(const kodi::addon::PVRChannel& channel)
     return false;
   }
 
-  P8PLATFORM::CLockObject critsec(live_mutex_);
+  std::lock_guard<std::mutex> critsec(live_mutex_);
 
   if (m_live_streamer)
     SafeDelete(m_live_streamer);
@@ -1749,7 +1749,7 @@ bool DVBLinkClient::IsRealTimeStream()
 
 PVR_ERROR DVBLinkClient::GetStreamTimes(kodi::addon::PVRStreamTimes& stream_times)
 {
-  P8PLATFORM::CLockObject critsec(live_mutex_);
+  std::lock_guard<std::mutex> critsec(live_mutex_);
 
   if (m_live_streamer)
   {
@@ -1766,7 +1766,7 @@ PVR_ERROR DVBLinkClient::GetStreamTimes(kodi::addon::PVRStreamTimes& stream_time
 
 int64_t DVBLinkClient::LengthLiveStream()
 {
-  P8PLATFORM::CLockObject critsec(live_mutex_);
+  std::lock_guard<std::mutex> critsec(live_mutex_);
 
   if (m_live_streamer)
     return m_live_streamer->Length();
@@ -1775,7 +1775,7 @@ int64_t DVBLinkClient::LengthLiveStream()
 
 void DVBLinkClient::CloseLiveStream()
 {
-  P8PLATFORM::CLockObject critsec(live_mutex_);
+  std::lock_guard<std::mutex> critsec(live_mutex_);
 
   if (m_live_streamer != nullptr)
   {

--- a/src/DVBLinkClient.h
+++ b/src/DVBLinkClient.h
@@ -16,7 +16,7 @@
 
 #include <kodi/addon-instance/PVR.h>
 #include <map>
-#include <p8-platform/threads/mutex.h>
+#include <mutex>
 #include <p8-platform/threads/threads.h>
 
 #define DVBLINK_BUILD_IN_RECORDER_SOURCE_ID "8F94B459-EFC0-4D91-9B29-EC3D72E92677"
@@ -240,8 +240,8 @@ private:
   int m_currentChannelId;
   long m_timerCount;
   long m_recordingCount;
-  P8PLATFORM::CMutex m_mutex;
-  P8PLATFORM::CMutex live_mutex_;
+  std::mutex m_mutex;
+  std::mutex live_mutex_;
   server_connection_properties connection_props_;
   LiveStreamerBase* m_live_streamer;
   RecordingStreamer* m_recording_streamer = nullptr;

--- a/src/DVBLinkClient.h
+++ b/src/DVBLinkClient.h
@@ -19,7 +19,6 @@
 #include <p8-platform/os.h>
 #include <p8-platform/threads/mutex.h>
 #include <p8-platform/threads/threads.h>
-#include <p8-platform/util/util.h>
 
 #define DVBLINK_BUILD_IN_RECORDER_SOURCE_ID "8F94B459-EFC0-4D91-9B29-EC3D72E92677"
 #define DVBLINK_RECODINGS_BY_DATA_ID "F6F08949-2A07-4074-9E9D-423D877270BB"

--- a/src/DVBLinkClient.h
+++ b/src/DVBLinkClient.h
@@ -16,7 +16,6 @@
 
 #include <kodi/addon-instance/PVR.h>
 #include <map>
-#include <p8-platform/os.h>
 #include <p8-platform/threads/mutex.h>
 #include <p8-platform/threads/threads.h>
 

--- a/src/RecordingStreamer.h
+++ b/src/RecordingStreamer.h
@@ -14,7 +14,6 @@
 #include <kodi/Filesystem.h>
 #include <kodi/addon-instance/PVR.h>
 #include <mutex>
-#include <p8-platform/threads/threads.h>
 
 class ATTRIBUTE_HIDDEN RecordingStreamer : public dvblinkremote::DVBLinkRemoteLocker
 {

--- a/src/RecordingStreamer.h
+++ b/src/RecordingStreamer.h
@@ -13,7 +13,6 @@
 
 #include <kodi/Filesystem.h>
 #include <kodi/addon-instance/PVR.h>
-#include <p8-platform/os.h>
 #include <p8-platform/threads/mutex.h>
 #include <p8-platform/threads/threads.h>
 

--- a/src/RecordingStreamer.h
+++ b/src/RecordingStreamer.h
@@ -13,7 +13,7 @@
 
 #include <kodi/Filesystem.h>
 #include <kodi/addon-instance/PVR.h>
-#include <p8-platform/threads/mutex.h>
+#include <mutex>
 #include <p8-platform/threads/threads.h>
 
 class ATTRIBUTE_HIDDEN RecordingStreamer : public dvblinkremote::DVBLinkRemoteLocker
@@ -50,14 +50,14 @@ protected:
   int port_;
   time_t prev_check_;
   time_t check_delta_;
-  P8PLATFORM::CMutex m_comm_mutex;
+  std::mutex m_comm_mutex;
 
   bool get_recording_info(const std::string& recording_id,
                           long long& recording_size,
                           long& recording_duration,
                           bool& is_in_recording);
 
-  virtual void lock() { m_comm_mutex.Lock(); }
+  virtual void lock() { m_comm_mutex.lock(); }
 
-  virtual void unlock() { m_comm_mutex.Unlock(); }
+  virtual void unlock() { m_comm_mutex.unlock(); }
 };

--- a/src/RecordingStreamer.h
+++ b/src/RecordingStreamer.h
@@ -16,7 +16,6 @@
 #include <p8-platform/os.h>
 #include <p8-platform/threads/mutex.h>
 #include <p8-platform/threads/threads.h>
-#include <p8-platform/util/util.h>
 
 class ATTRIBUTE_HIDDEN RecordingStreamer : public dvblinkremote::DVBLinkRemoteLocker
 {

--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -1,0 +1,717 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#include <kodi/General.h>
+#include "Socket.h"
+
+#include <chrono>
+#include <string>
+#include <thread>
+
+using namespace dvblink;
+
+namespace dvblink
+{
+
+/* Master defines for client control */
+constexpr long RECEIVE_TIMEOUT=6; //sec
+
+Socket::Socket(const enum SocketFamily family, const enum SocketDomain domain, const enum SocketType type, const enum SocketProtocol protocol)
+{
+  _sd = INVALID_SOCKET;
+  _family = family;
+  _domain = domain;
+  _type = type;
+  _protocol = protocol;
+  memset (&_sockaddr, 0, sizeof( _sockaddr ) );
+}
+
+
+Socket::Socket()
+{
+  // Default constructor, default settings
+  _sd = INVALID_SOCKET;
+  _family = af_inet;
+  _domain = pf_inet;
+  _type = sock_stream;
+  _protocol = tcp;
+  memset (&_sockaddr, 0, sizeof( _sockaddr ) );
+}
+
+
+Socket::~Socket()
+{
+  close();
+}
+
+bool Socket::setHostname ( const std::string& host )
+{
+  if (isalpha(host.c_str()[0]))
+  {
+    // host address is a name
+    struct hostent *he = nullptr;
+    if ((he = gethostbyname( host.c_str() )) == 0)
+    {
+      errormessage( getLastError(), "Socket::setHostname");
+      return false;
+    }
+
+    _sockaddr.sin_addr = *((in_addr *) he->h_addr);
+  }
+  else
+  {
+    _sockaddr.sin_addr.s_addr = inet_addr(host.c_str());
+  }
+  return true;
+}
+
+bool Socket::read_ready()
+{
+  fd_set fdset;
+
+  FD_ZERO(&fdset);
+  FD_SET(_sd, &fdset);
+
+  struct timeval tv = { 1, 0 };
+  //  tv.tv_sec = 1;
+
+  int retVal = select(_sd+1, &fdset, nullptr, nullptr, &tv);
+  if (retVal > 0)
+    return true;
+  return false;
+}
+
+
+bool Socket::close()
+{
+  if (is_valid())
+  {
+    if (_sd != SOCKET_ERROR)
+#ifdef TARGET_WINDOWS
+      closesocket(_sd);
+#else
+      ::close(_sd);
+#endif
+    _sd = INVALID_SOCKET;
+    osCleanup();
+    return true;
+  }
+  return false;
+}
+
+bool Socket::create()
+{
+  if( is_valid() )
+  {
+    close();
+  }
+
+  if(!osInit())
+  {
+    return false;
+  }
+
+  _sd = socket(_family, _type, _protocol );
+  //0 indicates that the default protocol for the type selected is to be used.
+  //For example, IPPROTO_TCP is chosen for the protocol if the type  was set to
+  //SOCK_STREAM and the address family is AF_INET.
+
+  if (_sd == INVALID_SOCKET)
+  {
+    errormessage( getLastError(), "Socket::create" );
+    return false;
+  }
+
+  return true;
+}
+
+
+bool Socket::bind ( const unsigned short port )
+{
+
+  if (!is_valid())
+  {
+    return false;
+  }
+
+  _sockaddr.sin_family = _family;
+  _sockaddr.sin_addr.s_addr = INADDR_ANY;  //listen to all
+  _sockaddr.sin_port = htons( port );
+
+  int bind_return = ::bind(_sd, (sockaddr*)(&_sockaddr), sizeof(_sockaddr));
+
+  if ( bind_return == -1 )
+  {
+    errormessage( getLastError(), "Socket::bind" );
+    return false;
+  }
+
+  return true;
+}
+
+
+bool Socket::listen() const
+{
+
+  if (!is_valid())
+  {
+    return false;
+  }
+
+  int listen_return = ::listen (_sd, SOMAXCONN);
+  //This is defined as 5 in winsock.h, and 0x7FFFFFFF in winsock2.h.
+  //linux 128//MAXCONNECTIONS =1
+
+  if (listen_return == -1)
+  {
+    errormessage( getLastError(), "Socket::listen" );
+    return false;
+  }
+
+  return true;
+}
+
+
+bool Socket::accept ( Socket& new_socket ) const
+{
+  if (!is_valid())
+  {
+    return false;
+  }
+
+  socklen_t addr_length = sizeof( _sockaddr );
+  new_socket._sd = ::accept(_sd, const_cast<sockaddr*>( (const sockaddr*) &_sockaddr), &addr_length );
+
+  if (new_socket._sd <= 0)
+  {
+    errormessage( getLastError(), "Socket::accept" );
+    return false;
+  }
+
+  return true;
+}
+
+
+int Socket::send ( const std::string& data )
+{
+  if (!is_valid())
+  {
+    return 0;
+  }
+  int status = 0;
+  do
+  {
+    status = Socket::send( (const char*) data.c_str(), (const unsigned int) data.size());
+#if defined(TARGET_WINDOWS)
+  } while (status == SOCKET_ERROR && errno == WSAEWOULDBLOCK);
+#else
+  } while (status == SOCKET_ERROR && errno == EAGAIN);
+#endif
+
+  return status;
+}
+
+
+int Socket::send ( const char* data, const unsigned int len )
+{
+  fd_set set_w, set_e;
+  struct timeval tv;
+  int  result;
+
+  if (!is_valid())
+  {
+    return 0;
+  }
+
+  // fill with new data
+  tv.tv_sec  = 0;
+  tv.tv_usec = 0;
+
+  FD_ZERO(&set_w);
+  FD_ZERO(&set_e);
+  FD_SET(_sd, &set_w);
+  FD_SET(_sd, &set_e);
+
+  result = select(FD_SETSIZE, &set_w, nullptr, &set_e, &tv);
+
+  if (result < 0)
+  {
+    kodi::Log(ADDON_LOG_ERROR, "Socket::send  - select failed");
+    _sd = INVALID_SOCKET;
+    return 0;
+  }
+  int status = 0;
+  do {
+    status = ::send(_sd, data, len, 0 );
+#if defined(TARGET_WINDOWS)
+  } while (status == SOCKET_ERROR && errno == WSAEWOULDBLOCK);
+#else
+  } while (status == SOCKET_ERROR && errno == EAGAIN);
+#endif
+  if (status == SOCKET_ERROR)
+  {
+    errormessage( getLastError(), "Socket::send");
+    kodi::Log(ADDON_LOG_ERROR, "Socket::send  - failed to send data");
+    _sd = INVALID_SOCKET;
+  }
+  return status;
+}
+
+
+int Socket::sendto ( const char* data, unsigned int size, bool sendcompletebuffer)
+{
+  int sentbytes = 0;
+  int i;
+
+  do
+  {
+    i = ::sendto(_sd, data, size, 0, (const struct sockaddr*) &_sockaddr, sizeof( _sockaddr ) );
+
+    if (i <= 0)
+    {
+      errormessage( getLastError(), "Socket::sendto");
+      osCleanup();
+      return i;
+    }
+    sentbytes += i;
+  } while ( (sentbytes < (int) size) && (sendcompletebuffer == true));
+
+  return i;
+}
+
+
+int Socket::receive ( std::string& data, unsigned int minpacketsize ) const
+{
+  char * buf = nullptr;
+  int status = 0;
+
+  if (!is_valid())
+  {
+    return 0;
+  }
+
+  buf = new char [ minpacketsize + 1 ];
+  memset ( buf, 0, minpacketsize + 1 );
+
+  status = receive( buf, minpacketsize, minpacketsize );
+
+  data = buf;
+
+  delete[] buf;
+  return status;
+}
+
+int Socket::receive ( std::string& data) const
+{
+  char buf[MAXRECV + 1];
+  int status = 0;
+
+  if ( !is_valid() )
+  {
+    return 0;
+  }
+
+  memset ( buf, 0, MAXRECV + 1 );
+  status = receive( buf, MAXRECV, 0 );
+  data = buf;
+
+  return status;
+}
+
+int Socket::receive ( char* data, const unsigned int buffersize, const unsigned int minpacketsize ) const
+{
+  return receive( data, buffersize, minpacketsize, -1);
+}
+
+int Socket::receive ( char* data, const unsigned int buffersize, const unsigned int minpacketsize, const int readtimeoutms ) const
+{
+
+  unsigned int receivedsize = 0;
+  int status = 0;
+
+  if ( !is_valid() )
+  {
+    return 0;
+  }
+
+  auto target = std::chrono::system_clock::now() + std::chrono::milliseconds(readtimeoutms);
+
+  while ( (receivedsize <= minpacketsize) && (receivedsize < buffersize) && 
+          (readtimeoutms < 0 || std::chrono::system_clock::now() < target ) )
+  {
+    status = ::recv(_sd, data+receivedsize, (buffersize - receivedsize), 0 );
+
+    if ( status == SOCKET_ERROR )
+    {
+      int lasterror = getLastError();
+#if defined(TARGET_WINDOWS)
+      if ( lasterror != WSAEWOULDBLOCK)
+#else
+      if ( lasterror != EAGAIN )
+#endif
+      {
+        errormessage( lasterror, "Socket::receive" );
+      }
+      else
+      {
+        kodi::Log(ADDON_LOG_ERROR, "Socket::read EAGAIN");
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        continue;
+      }
+      return status;
+    }
+
+    receivedsize += status;
+
+  if (receivedsize >= minpacketsize)
+    break;
+  }
+
+  return receivedsize;
+}
+
+
+int Socket::recvfrom ( char* data, const int buffersize, struct sockaddr* from, socklen_t* fromlen) const
+{
+  int status = ::recvfrom(_sd, data, buffersize, 0, from, fromlen);
+
+  return status;
+}
+
+
+bool Socket::connect ( const std::string& host, const unsigned short port )
+{
+  if ( !is_valid() )
+  {
+    return false;
+  }
+
+  _sockaddr.sin_family = _family;
+  _sockaddr.sin_port = htons ( port );
+
+  if ( !setHostname( host ) )
+  {
+    kodi::Log(ADDON_LOG_ERROR, "Socket::setHostname(%s) failed.\n", host.c_str());
+    return false;
+  }
+
+  int status = ::connect ( _sd, reinterpret_cast<sockaddr*>(&_sockaddr), sizeof ( _sockaddr ) );
+
+  if ( status == SOCKET_ERROR )
+  {
+    kodi::Log(ADDON_LOG_ERROR, "Socket::connect %s:%u\n", host.c_str(), port);
+    errormessage( getLastError(), "Socket::connect" );
+    return false;
+  }
+
+  return true;
+}
+
+bool Socket::reconnect()
+{
+  if ( _sd != INVALID_SOCKET )
+  {
+    return true;
+  }
+
+  if( !create() )
+    return false;
+
+  int status = ::connect ( _sd, reinterpret_cast<sockaddr*>(&_sockaddr), sizeof ( _sockaddr ) );
+
+  if ( status == SOCKET_ERROR )
+  {
+    errormessage( getLastError(), "Socket::connect" );
+    return false;
+  }
+
+  return true;
+}
+
+bool Socket::is_valid() const
+{
+  return (_sd != INVALID_SOCKET);
+}
+
+bool Socket::SetSocketOption(int level, int option, char* setting, int value)
+{
+  if (_sd == INVALID_SOCKET)
+  {
+    return false;
+  }
+  return setsockopt(_sd, level, option, setting, value);
+}
+
+int Socket::BroadcastSendTo(int port, const char* msg, int len)
+{
+  _sockaddr.sin_family = _family;
+  _sockaddr.sin_port = htons(port);
+  _sockaddr.sin_addr.s_addr = inet_addr("255.255.255.255");
+  return sendto(msg, len);
+}
+
+int Socket::BroadcastReceiveFrom(char* payload, int payloadLength)
+{
+  socklen_t len = sizeof(_sockaddr);
+  return recvfrom(payload, payloadLength, (sockaddr*)&_sockaddr, &len);
+}
+
+#if defined(TARGET_WINDOWS)
+bool Socket::set_non_blocking ( const bool b )
+{
+  u_long iMode;
+
+  if ( b )
+    iMode = 1;  // enable non_blocking
+  else
+    iMode = 0;  // disable non_blocking
+
+  if (ioctlsocket(_sd, FIONBIO, &iMode) == -1)
+  {
+    kodi::Log(ADDON_LOG_ERROR, "Socket::set_non_blocking - Can't set socket condition to: %i", iMode);
+    return false;
+  }
+
+  return true;
+}
+
+void Socket::errormessage( int errnum, const char* functionname) const
+{
+  const char* errmsg = nullptr;
+
+  switch (errnum)
+  {
+  case WSANOTINITIALISED:
+    errmsg = "A successful WSAStartup call must occur before using this function.";
+    break;
+  case WSAENETDOWN:
+    errmsg = "The network subsystem or the associated service provider has failed";
+    break;
+  case WSA_NOT_ENOUGH_MEMORY:
+    errmsg = "Insufficient memory available";
+    break;
+  case WSA_INVALID_PARAMETER:
+    errmsg = "One or more parameters are invalid";
+    break;
+  case WSA_OPERATION_ABORTED:
+    errmsg = "Overlapped operation aborted";
+    break;
+  case WSAEINTR:
+    errmsg = "Interrupted function call";
+    break;
+  case WSAEBADF:
+    errmsg = "File handle is not valid";
+    break;
+  case WSAEACCES:
+    errmsg = "Permission denied";
+    break;
+  case WSAEFAULT:
+    errmsg = "Bad address";
+    break;
+  case WSAEINVAL:
+    errmsg = "Invalid argument";
+    break;
+  case WSAENOTSOCK:
+    errmsg = "Socket operation on nonsocket";
+    break;
+  case WSAEDESTADDRREQ:
+    errmsg = "Destination address required";
+    break;
+  case WSAEMSGSIZE:
+    errmsg = "Message too long";
+    break;
+  case WSAEPROTOTYPE:
+    errmsg = "Protocol wrong type for socket";
+    break;
+  case WSAENOPROTOOPT:
+    errmsg = "Bad protocol option";
+    break;
+  case WSAEPFNOSUPPORT:
+    errmsg = "Protocol family not supported";
+    break;
+  case WSAEAFNOSUPPORT:
+    errmsg = "Address family not supported by protocol family";
+    break;
+  case WSAEADDRINUSE:
+    errmsg = "Address already in use";
+    break;
+  case WSAECONNRESET:
+    errmsg = "Connection reset by peer";
+    break;
+  case WSAHOST_NOT_FOUND:
+    errmsg = "Authoritative answer host not found";
+    break;
+  case WSATRY_AGAIN:
+    errmsg = "Nonauthoritative host not found, or server failure";
+    break;
+  case WSAEISCONN:
+    errmsg = "Socket is already connected";
+    break;
+  case WSAETIMEDOUT:
+    errmsg = "Connection timed out";
+    break;
+  case WSAECONNREFUSED:
+    errmsg = "Connection refused";
+    break;
+  case WSANO_DATA:
+    errmsg = "Valid name, no data record of requested type";
+    break;
+  default:
+    errmsg = "WSA Error";
+  }
+  kodi::Log(ADDON_LOG_ERROR, "%s: (Winsock error=%i) %s\n", functionname, errnum, errmsg);
+}
+
+int Socket::getLastError() const
+{
+  return WSAGetLastError();
+}
+
+int Socket::win_usage_count = 0; //Declared static in Socket class
+
+bool Socket::osInit()
+{
+  win_usage_count++;
+  // initialize winsock:
+  if (WSAStartup(MAKEWORD(2, 2), &_wsaData) != 0)
+  {
+    return false;
+  }
+
+  WORD wVersionRequested = MAKEWORD(2, 2);
+
+  // check version
+  if (_wsaData.wVersion != wVersionRequested)
+  {
+    return false;
+  }
+
+  return true;
+}
+
+void Socket::osCleanup()
+{
+  win_usage_count--;
+  if(win_usage_count == 0)
+  {
+    WSACleanup();
+  }
+}
+
+#elif defined TARGET_LINUX || defined TARGET_DARWIN || defined TARGET_FREEBSD
+bool Socket::set_non_blocking ( const bool b )
+{
+  int opts;
+
+  opts = fcntl(_sd, F_GETFL);
+
+  if ( opts < 0 )
+  {
+    return false;
+  }
+
+  if ( b )
+    opts = ( opts | O_NONBLOCK );
+  else
+    opts = ( opts & ~O_NONBLOCK );
+
+  if(fcntl (_sd , F_SETFL, opts) == -1)
+  {
+    kodi::Log(ADDON_LOG_ERROR, "Socket::set_non_blocking - Can't set socket flags to: %i", opts);
+    return false;
+  }
+  return true;
+}
+
+void Socket::errormessage( int errnum, const char* functionname) const
+{
+  const char* errmsg = nullptr;
+
+  switch ( errnum )
+  {
+    case EAGAIN: //same as EWOULDBLOCK
+      errmsg = "EAGAIN: The socket is marked non-blocking and the requested operation would block";
+      break;
+    case EBADF:
+      errmsg = "EBADF: An invalid descriptor was specified";
+      break;
+    case ECONNRESET:
+      errmsg = "ECONNRESET: Connection reset by peer";
+      break;
+    case EDESTADDRREQ:
+      errmsg = "EDESTADDRREQ: The socket is not in connection mode and no peer address is set";
+      break;
+    case EFAULT:
+      errmsg = "EFAULT: An invalid userspace address was specified for a parameter";
+      break;
+    case EINTR:
+      errmsg = "EINTR: A signal occurred before data was transmitted";
+      break;
+    case EINVAL:
+      errmsg = "EINVAL: Invalid argument passed";
+      break;
+    case ENOTSOCK:
+      errmsg = "ENOTSOCK: The argument is not a valid socket";
+      break;
+    case EMSGSIZE:
+      errmsg = "EMSGSIZE: The socket requires that message be sent atomically, and the size of the message to be sent made this impossible";
+      break;
+    case ENOBUFS:
+      errmsg = "ENOBUFS: The output queue for a network interface was full";
+      break;
+    case ENOMEM:
+      errmsg = "ENOMEM: No memory available";
+      break;
+    case EPIPE:
+      errmsg = "EPIPE: The local end has been shut down on a connection oriented socket";
+      break;
+    case EPROTONOSUPPORT:
+      errmsg = "EPROTONOSUPPORT: The protocol type or the specified protocol is not supported within this domain";
+      break;
+    case EAFNOSUPPORT:
+      errmsg = "EAFNOSUPPORT: The implementation does not support the specified address family";
+      break;
+    case ENFILE:
+      errmsg = "ENFILE: Not enough kernel memory to allocate a new socket structure";
+      break;
+    case EMFILE:
+      errmsg = "EMFILE: Process file table overflow";
+      break;
+    case EACCES:
+      errmsg = "EACCES: Permission to create a socket of the specified type and/or protocol is denied";
+      break;
+    case ECONNREFUSED:
+      errmsg = "ECONNREFUSED: A remote host refused to allow the network connection (typically because it is not running the requested service)";
+      break;
+    case ENOTCONN:
+      errmsg = "ENOTCONN: The socket is associated with a connection-oriented protocol and has not been connected";
+      break;
+    default:
+      break;
+  }
+  kodi::Log(ADDON_LOG_ERROR, "%s: (errno=%i) %s\n", functionname, errnum, errmsg);
+}
+
+int Socket::getLastError() const
+{
+  return errno;
+}
+
+bool Socket::osInit()
+{
+  // Not needed for Linux
+  return true;
+}
+
+void Socket::osCleanup()
+{
+  // Not needed for Linux
+}
+#endif //TARGET_WINDOWS || TARGET_LINUX || TARGET_DARWIN || TARGET_FREEBSD
+
+} //namespace NextPVR

--- a/src/Socket.h
+++ b/src/Socket.h
@@ -1,0 +1,309 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#pragma once
+
+//Include platform specific datatypes, header files, defines and constants:
+#if defined TARGET_WINDOWS
+  #define WIN32_LEAN_AND_MEAN           // Enable LEAN_AND_MEAN support
+  #pragma warning(disable:4005) // Disable "warning C4005: '_WINSOCKAPI_' : macro redefinition"
+  #include <winsock2.h>
+  #pragma warning(default:4005)
+  #include <windows.h>
+
+  #ifndef NI_MAXHOST
+    #define NI_MAXHOST 1025
+  #endif
+
+  #ifndef socklen_t
+    typedef int socklen_t;
+  #endif
+  #ifndef ipaddr_t
+    typedef unsigned long ipaddr_t;
+  #endif
+  #ifndef port_t
+    typedef unsigned short port_t;
+  #endif
+#elif defined TARGET_LINUX || defined TARGET_DARWIN || defined TARGET_FREEBSD
+#ifdef SOCKADDR_IN
+#undef SOCKADDR_IN
+#endif
+  #include <sys/types.h>     /* for socket,connect */
+  #include <sys/socket.h>    /* for socket,connect */
+  #include <sys/un.h>        /* for Unix socket */
+  #include <arpa/inet.h>     /* for inet_pton */
+  #include <netdb.h>         /* for gethostbyname */
+  #include <netinet/in.h>    /* for htons */
+  #include <unistd.h>        /* for read, write, close */
+  #include <errno.h>
+  #include <fcntl.h>
+
+  typedef int SOCKET;
+  typedef sockaddr SOCKADDR;
+  typedef sockaddr_in SOCKADDR_IN;
+  #ifndef INVALID_SOCKET
+  #define INVALID_SOCKET (-1)
+  #endif
+  #define SOCKET_ERROR (-1)
+#else
+  #error Platform specific socket support is not yet available on this platform!
+#endif
+
+
+#include <vector>
+
+namespace dvblink
+{
+
+#define MAXCONNECTIONS 1  ///< Maximum number of pending connections before "Connection refused"
+#define MAXRECV 1500      ///< Maximum packet size
+
+enum SocketFamily
+{
+  #ifdef CONFIG_SOCKET_IPV6
+    af_inet6  = AF_INET6,
+    af_unspec = AF_UNSPEC,    ///< Either INET or INET6
+  #endif
+  af_inet = AF_INET
+};
+
+enum SocketDomain
+{
+  #if defined TARGET_LINUX || defined TARGET_DARWIN || defined TARGET_FREEBSD
+    pf_unix  = PF_UNIX,
+    pf_local = PF_LOCAL,
+  #endif
+  #ifdef CONFIG_SOCKET_IPV6
+    pf_inet6  = PF_INET6,
+    pf_unspec = PF_UNSPEC,    //< Either INET or INET6
+  #endif
+  pf_inet = PF_INET
+};
+
+enum SocketType
+{
+  sock_stream = SOCK_STREAM,
+  sock_dgram = SOCK_DGRAM
+};
+
+enum SocketProtocol
+{
+  tcp = IPPROTO_TCP,
+  udp = IPPROTO_UDP
+  #ifdef CONFIG_SOCKET_IPV6
+    , ipv6 = IPPROTO_IPV6
+  #endif
+};
+
+class Socket
+{
+  public:
+
+    /*!
+     * An unconnected socket may be created directly on the local
+     * machine. The socket type (SOCK_STREAM, SOCK_DGRAM) and
+     * protocol may also be specified.
+     * If the socket cannot be created, an exception is thrown.
+     *
+     * \param family Socket family (IPv4 or IPv6)
+     * \param domain The domain parameter specifies a communications domain within which communication will take place;
+     * this selects the protocol family which should be used.
+     * \param type base type and protocol family of the socket.
+     * \param protocol specific protocol to apply.
+     */
+    Socket(const enum SocketFamily family, const enum SocketDomain domain, const enum SocketType type, const enum SocketProtocol protocol = tcp);
+    Socket(void);
+    virtual ~Socket();
+
+    //Socket settings
+
+    /*!
+     * Socket setFamily
+     * \param family    Can be af_inet or af_inet6. Default: af_inet
+     */
+    void setFamily(const enum SocketFamily family)
+    {
+      _family = family;
+    };
+
+    /*!
+     * Socket setDomain
+     * \param domain    Can be pf_unix, pf_local, pf_inet or pf_inet6. Default: pf_inet
+     */
+    void setDomain(const enum SocketDomain domain)
+    {
+      _domain = domain;
+    };
+
+    /*!
+     * Socket setType
+     * \param type    Can be sock_stream or sock_dgram. Default: sock_stream.
+     */
+    void setType(const enum SocketType type)
+    {
+      _type = type;
+    };
+
+    /*!
+     * Socket setProtocol
+     * \param protocol    Can be tcp or udp. Default: tcp.
+     */
+    void setProtocol(const enum SocketProtocol protocol)
+    {
+      _protocol = protocol;
+    };
+
+    /*!
+     * Socket setPort
+     * \param port    port number for socket communication
+     */
+    void setPort (const unsigned short port)
+    {
+      _sockaddr.sin_port = htons ( port );
+    };
+
+    bool setHostname ( const std::string& host );
+
+    // Server initialization
+
+    /*!
+     * Socket create
+     * Create a new socket
+     * \return     True if succesful
+     */
+    bool create();
+
+    /*!
+     * Socket close
+     * Close the socket
+     * \return     True if succesful
+     */
+    bool close();
+
+    /*!
+     * Socket bind
+     */
+    bool bind ( const unsigned short port );
+    bool listen() const;
+    bool accept ( Socket& socket ) const;
+
+    // Client initialization
+    bool connect ( const std::string& host, const unsigned short port );
+
+    bool reconnect();
+
+    // Data Transmission
+
+    /*!
+     * Socket send function
+     *
+     * \param data    Reference to a std::string with the data to transmit
+     * \return    Number of bytes send or -1 in case of an error
+     */
+    int send ( const std::string& data );
+
+    /*!
+     * Socket send function
+     *
+     * \param data    Pointer to a character array of size 'size' with the data to transmit
+     * \param size    Length of the data to transmit
+     * \return    Number of bytes send or -1 in case of an error
+     */
+    int send ( const char* data, const unsigned int size );
+
+    /*!
+     * Socket sendto function
+     *
+     * \param data    Reference to a std::string with the data to transmit
+     * \param size    Length of the data to transmit
+     * \param sendcompletebuffer    If 'true': do not return until the complete buffer is transmitted
+     * \return    Number of bytes send or -1 in case of an error
+     */
+    int sendto ( const char* data, unsigned int size, bool sendcompletebuffer = false);
+    // Data Receive
+
+    /*!
+     * Socket receive function
+     *
+     * \param data    Reference to a std::string for storage of the received data.
+     * \param minpacketsize    The minimum number of bytes that should be received before returning from this function
+     * \return    Number of bytes received or SOCKET_ERROR
+     */
+    int receive ( std::string& data, unsigned int minpacketsize ) const;
+
+    /*!
+     * Socket receive function
+     *
+     * \param data    Reference to a std::string for storage of the received data.
+     * \return    Number of bytes received or SOCKET_ERROR
+     */
+    int receive ( std::string& data ) const;
+
+    /*!
+     * Socket receive function
+     *
+     * \param data    Pointer to a character array of size buffersize. Used to store the received data.
+     * \param buffersize    Size of the 'data' buffer
+     * \param minpacketsize    Specifies the minimum number of bytes that need to be received before returning
+     * \return    Number of bytes received or SOCKET_ERROR
+     */
+    int receive ( char* data, const unsigned int buffersize, const unsigned int minpacketsize ) const;
+
+    /*!
+     * Socket receive function
+     *
+     * \param data    Pointer to a character array of size buffersize. Used to store the received data.
+     * \param buffersize    Size of the 'data' buffer
+     * \param minpacketsize    Specifies the minimum number of bytes that need to be received before returning
+     * \param readtimeoutms    Specifies the amount of time after which this call will timeout. -1 to disable timeout
+     * \return    Number of bytes received or SOCKET_ERROR
+     */
+    int receive ( char* data, const unsigned int buffersize, const unsigned int minpacketsize, const int readtimeoutms ) const;
+
+    /*!
+     * Socket recvfrom function
+     *
+     * \param data    Pointer to a character array of size buffersize. Used to store the received data.
+     * \param buffersize    Size of the 'data' buffer
+     * \param from        Optional: pointer to a sockaddr struct that will get the address from which the data is received
+     * \param fromlen    Optional, only required if 'from' is given: length of from struct
+     * \return    Number of bytes received or SOCKET_ERROR
+     */
+    int recvfrom ( char* data, const int buffersize, struct sockaddr* from = nullptr, socklen_t* fromlen = nullptr) const;
+
+    bool set_non_blocking ( const bool );
+
+    bool is_valid() const;
+
+    bool SetSocketOption(int level, int option, char* setting, int value);
+    int BroadcastSendTo(int port, const char* msg, int len);
+    int BroadcastReceiveFrom(char* payload, int payloadLength);
+    bool read_ready();
+
+  private:
+
+    SOCKET _sd;                         ///< Socket Descriptor
+    SOCKADDR_IN _sockaddr;              ///< Socket Address
+
+    enum SocketFamily _family;          ///< Socket Address Family
+    enum SocketProtocol _protocol;      ///< Socket Protocol
+    enum SocketType _type;              ///< Socket Type
+    enum SocketDomain _domain;          ///< Socket domain
+
+    #ifdef TARGET_WINDOWS
+      WSADATA _wsaData;                 ///< Windows Socket data
+      static int win_usage_count;       ///< Internal Windows usage counter used to prevent a global WSACleanup when more than one Socket object is used
+    #endif
+
+    void errormessage( int errornum, const char* functionname = nullptr) const;
+    int getLastError(void) const;
+    bool osInit();
+    void osCleanup();
+};
+
+} //namespace dvblink

--- a/src/TimeShiftBuffer.cpp
+++ b/src/TimeShiftBuffer.cpp
@@ -66,7 +66,7 @@ bool LiveStreamerBase::Start(Channel* channel,
         kodi::QueueNotification(QUEUE_ERROR, "", kodi::GetLocalizedString(30007));
     }
 
-    SAFE_DELETE(sr);
+    SafeDelete(sr);
   }
   else
   {
@@ -94,7 +94,7 @@ void LiveStreamerBase::Stop()
                 (int)status, error.c_str());
     }
 
-    SAFE_DELETE(request);
+    SafeDelete(request);
   }
   }
 
@@ -209,7 +209,7 @@ void LiveStreamerBase::Stop()
         ret_val = buffer_params.cur_pos;
       }
 
-      SAFE_DELETE(request);
+      SafeDelete(request);
     }
     else
     {
@@ -348,7 +348,7 @@ void LiveStreamerBase::Stop()
           ret_val = true;
         }
 
-        SAFE_DELETE(request);
+        SafeDelete(request);
       } else
       {
         std::string req_url = streampath_;

--- a/src/TimeShiftBuffer.h
+++ b/src/TimeShiftBuffer.h
@@ -12,7 +12,6 @@
 
 #include <kodi/Filesystem.h>
 #include <kodi/addon-instance/pvr/Stream.h>
-#include <p8-platform/os.h>
 
 class ATTRIBUTE_HIDDEN LiveStreamerBase
 {

--- a/src/TimeShiftBuffer.h
+++ b/src/TimeShiftBuffer.h
@@ -13,7 +13,6 @@
 #include <kodi/Filesystem.h>
 #include <kodi/addon-instance/pvr/Stream.h>
 #include <p8-platform/os.h>
-#include <p8-platform/util/util.h>
 
 class ATTRIBUTE_HIDDEN LiveStreamerBase
 {

--- a/src/addon.cpp
+++ b/src/addon.cpp
@@ -37,7 +37,7 @@ ADDON_STATUS CDVBLinkAddon::CreateInstance(int instanceType,
 
     addonInstance = client;
 
-    if (client->GetStatus())
+    if (!client->GetStatus())
       return ADDON_STATUS_LOST_CONNECTION;
 
     return ADDON_STATUS_OK;

--- a/src/dvblink_connection.h
+++ b/src/dvblink_connection.h
@@ -11,7 +11,7 @@
 #include "HttpPostClient.h"
 #include "libdvblinkremote/dvblinkremote.h"
 
-#include <p8-platform/threads/mutex.h>
+#include <mutex>
 #include <p8-platform/threads/threads.h>
 
 template<typename T> void SafeDelete(T*& p)
@@ -67,11 +67,11 @@ public:
   dvblinkremote::IDVBLinkRemoteConnection* get_connection() { return dvblink_connection_; }
 
 protected:
-  virtual void lock() { m_comm_mutex.Lock(); }
+  virtual void lock() { m_comm_mutex.lock(); }
 
-  virtual void unlock() { m_comm_mutex.Unlock(); }
+  virtual void unlock() { m_comm_mutex.unlock(); }
 
-  P8PLATFORM::CMutex m_comm_mutex;
+  std::mutex m_comm_mutex;
   HttpPostClient* http_client_;
   dvblinkremote::IDVBLinkRemoteConnection* dvblink_connection_;
 };

--- a/src/dvblink_connection.h
+++ b/src/dvblink_connection.h
@@ -14,7 +14,15 @@
 #include <p8-platform/os.h>
 #include <p8-platform/threads/mutex.h>
 #include <p8-platform/threads/threads.h>
-#include <p8-platform/util/util.h>
+
+template<typename T> void SafeDelete(T*& p)
+{
+  if (p)
+  {
+    delete p;
+    p = nullptr;
+  }
+}
 
 struct ATTRIBUTE_HIDDEN server_connection_properties
 {
@@ -53,8 +61,8 @@ public:
 
   ~dvblink_server_connection()
   {
-    SAFE_DELETE(dvblink_connection_);
-    SAFE_DELETE(http_client_);
+    SafeDelete(dvblink_connection_);
+    SafeDelete(http_client_);
   }
 
   dvblinkremote::IDVBLinkRemoteConnection* get_connection() { return dvblink_connection_; }

--- a/src/dvblink_connection.h
+++ b/src/dvblink_connection.h
@@ -12,7 +12,6 @@
 #include "libdvblinkremote/dvblinkremote.h"
 
 #include <mutex>
-#include <p8-platform/threads/threads.h>
 
 template<typename T> void SafeDelete(T*& p)
 {

--- a/src/dvblink_connection.h
+++ b/src/dvblink_connection.h
@@ -11,7 +11,6 @@
 #include "HttpPostClient.h"
 #include "libdvblinkremote/dvblinkremote.h"
 
-#include <p8-platform/os.h>
 #include <p8-platform/threads/mutex.h>
 #include <p8-platform/threads/threads.h>
 


### PR DESCRIPTION
v9.0.1
- Remove p8-platform dependency
- Use different socket implementation
- Remove use of SAFE_DELETE and p8 util header
- Remove p8 os header
- Use std::mutex
- Use std::thread
- Fix proper return value if connected
- Update inputstream API 3.0.1 - Fix wrong flags bit shift