### PR TITLE
[Nexus] Add supports recordings delete capability for PVR API 8.0.0

### DIFF
--- a/pvr.dvblink/addon.xml.in
+++ b/pvr.dvblink/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.dvblink"
-  version="20.0.0"
+  version="20.1.0"
   name="TVMosaic/DVBLink PVR Client"
   provider-name="DVBLogic">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.dvblink/changelog.txt
+++ b/pvr.dvblink/changelog.txt
@@ -1,3 +1,8 @@
+v20.1.0
+- Kodi PVR API to 8.0.0
+  - Add supports recordings delete capability
+  - Enforce EDL limits
+
 v20.0.0
 - Updated dependency TinyXML2 to version 9.0.0
 - Language update

--- a/src/DVBLinkClient.cpp
+++ b/src/DVBLinkClient.cpp
@@ -282,6 +282,7 @@ PVR_ERROR DVBLinkClient::GetCapabilities(kodi::addon::PVRCapabilities& capabilit
 
   capabilities.SetSupportsEPG(true);
   capabilities.SetSupportsRecordings(server_caps_.recordings_supported_);
+  capabilities.SetSupportsRecordingsDelete(server_caps_.recordings_supported_);
   capabilities.SetSupportsRecordingsUndelete(false);
   capabilities.SetSupportsTimers(server_caps_.recordings_supported_);
   capabilities.SetSupportsTV(true);


### PR DESCRIPTION
- Kodi API to 8.0.0
  - Add supports recordings delete capability
  - Enforce EDL limits

This PR should be rebuilt via Jenkins after these xbmc PRs are merged:
- https://github.com/xbmc/xbmc/pull/20009
- https://github.com/xbmc/xbmc/pull/19395