### PR TITLE
[Nexus] Increase version to 20.3.0

### DIFF
--- a/pvr.dvblink/addon.xml.in
+++ b/pvr.dvblink/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.dvblink"
-  version="20.2.0"
+  version="20.3.0"
   name="TVMosaic/DVBLink PVR Client"
   provider-name="DVBLogic">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.dvblink/changelog.txt
+++ b/pvr.dvblink/changelog.txt
@@ -1,3 +1,6 @@
+v20.3.0
+- Kodi inputstream API update to version 3.2.0
+
 v20.2.0
 - Translation updates by Weblate
 - Kodi main API update to version 2.0.0


### PR DESCRIPTION
Bump version for inpustream API change
due to:
https://github.com/xbmc/xbmc/pull/21390
https://github.com/xbmc/xbmc/pull/21319
